### PR TITLE
Move canon map to memory code to a libblant function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ test_blant:
 	# Test to see that for k=6, the most frequent 10 graphlets in syeast appear in the expected order in frequency
 	# Need 10 million samples to ensure with high probability we get the same graphlets.
 	# We then sort them because the top 10 are a pretty stable set but their order is not.
-	# The -2 also tests parallelism, attemting to run 2 threads simultaneously.
+	# The -t option tests parallelism, attemting to run multiple threads simultaneously.
 	# NOTE THIS WILL FAIL UNLESS YOU SET BOTH LOWER_TRIANGLE AND PERMS_CAN2NON TO 1 IN blant.h.
-	for k in 3 4 5 6 7 8; do if [ -f canon_maps/canon_map$$k.bin ]; then echo checking frequency of graphlets in syeast.el for "k=$$k"; ./blant -4 $$k 10000000 syeast.el | awk '{++count[$$1]}END{for(i in count) print count[i],i}' | sort -nr | head | awk '{print $$2}' | sort -n | diff -b - blant.k$$k.syeast.out; fi; done
+	for k in 3 4 5 6 7 8; do if [ -f canon_maps/canon_map$$k.bin ]; then echo checking frequency of graphlets in syeast.el for "k=$$k"; ./blant -t 4 $$k 10000000 syeast.el | awk '{++count[$$1]}END{for(i in count) print count[i],i}' | sort -nr | head | awk '{print $$2}' | sort -n | diff -b - blant.k$$k.syeast.out; fi; done
 
 canon_maps: libwayne canon_maps/canon_map6.txt blant.h test_maps subcanon_maps
 

--- a/blant.c
+++ b/blant.c
@@ -524,7 +524,7 @@ void SetGlobalCanonMaps(void)
     _canonList = Calloc(_numCanon, sizeof(*_canonList));
     for(i=0; i<_numCanon; i++) fscanf(fp_ord, "%d", &_canonList[i]);
     fclose(fp_ord);
-    createCanonMap(BUF, _K, _k);
+    mapCanonMap(BUF, _K, _k);
     sprintf(BUF, CANON_DIR "/perm_map%d.bin", _k);
     int pfd = open(BUF, 0*O_RDONLY);
     kperm *Pf = Mmap(Permutations, _Bk*sizeof(Permutations[0]), pfd);

--- a/blant.c
+++ b/blant.c
@@ -524,7 +524,7 @@ void SetGlobalCanonMaps(void)
     _canonList = Calloc(_numCanon, sizeof(*_canonList));
     for(i=0; i<_numCanon; i++) fscanf(fp_ord, "%d", &_canonList[i]);
     fclose(fp_ord);
-    short int *Kf = createCanonMap(BUF, _K, _k);
+    createCanonMap(BUF, _K, _k);
     sprintf(BUF, CANON_DIR "/perm_map%d.bin", _k);
     int pfd = open(BUF, 0*O_RDONLY);
     kperm *Pf = Mmap(Permutations, _Bk*sizeof(Permutations[0]), pfd);

--- a/blant.c
+++ b/blant.c
@@ -520,13 +520,10 @@ void SetGlobalCanonMaps(void)
     int canon_list[numCanon], i;
     for(i=0; i<numCanon; i++) fscanf(fp_ord, "%d", &canon_list[i]);
     fclose(fp_ord);
-    sprintf(BUF, CANON_DIR "/canon_map%d.bin", _k);
-    int Kfd = open(BUF, 0*O_RDONLY);
+    short int *Kf = createCanonMap(BUF, _K, _k);
     sprintf(BUF, CANON_DIR "/perm_map%d.bin", _k);
     int pfd = open(BUF, 0*O_RDONLY);
-    short int *Kf = Mmap(_K, _Bk*sizeof(_K[0]), Kfd);
     kperm *Pf = Mmap(Permutations, _Bk*sizeof(Permutations[0]), pfd);
-    assert(Kf == _K);
     assert(Pf == Permutations);
 }
 

--- a/blant.h
+++ b/blant.h
@@ -25,4 +25,4 @@
 
 void BuildGraph(TINY_GRAPH* G, int Gint);
 int TinyGraph2Int(TINY_GRAPH *g, int numNodes);
-void createCanonMap(char* BUF, short int *K, int k);
+void mapCanonMap(char* BUF, short int *K, int k);

--- a/blant.h
+++ b/blant.h
@@ -25,3 +25,4 @@
 
 void BuildGraph(TINY_GRAPH* G, int Gint);
 int TinyGraph2Int(TINY_GRAPH *g, int numNodes);
+short int *createCanonMap(char* BUF, short int *K, int k);

--- a/blant.h
+++ b/blant.h
@@ -25,4 +25,4 @@
 
 void BuildGraph(TINY_GRAPH* G, int Gint);
 int TinyGraph2Int(TINY_GRAPH *g, int numNodes);
-short int *createCanonMap(char* BUF, short int *K, int k);
+void createCanonMap(char* BUF, short int *K, int k);

--- a/libblant.c
+++ b/libblant.c
@@ -61,7 +61,7 @@ void BuildGraph(TINY_GRAPH* G, int Gint)
 ** Given a pre-allocated filename buffer, a 256MB aligned array K, num nodes k
 ** Mmap the canon_map binary file to the aligned array. 
 */
-short int *createCanonMap(char* BUF, short int *K, int k) {
+void createCanonMap(char* BUF, short int *K, int k) {
     int Bk = (1 <<(k*(k-1)/2));
     sprintf(BUF, CANON_DIR "/canon_map%d.bin", k);
     int Kfd = open(BUF, 0*O_RDONLY);

--- a/libblant.c
+++ b/libblant.c
@@ -1,3 +1,4 @@
+#include <sys/file.h>
 #include "blant.h"
 
 // Given a TINY_GRAPH and k, return the integer ID created from one triangle (upper or lower) of the adjacency matrix.
@@ -54,4 +55,17 @@ void BuildGraph(TINY_GRAPH* G, int Gint)
 	}
 	if(!Gint2) break;
     }
+}
+
+/*
+** Given a pre-allocated filename buffer, a 256MB aligned array K, num nodes k
+** Mmap the canon_map binary file to the aligned array. 
+*/
+short int *createCanonMap(char* BUF, short int *K, int k) {
+    int Bk = (1 <<(k*(k-1)/2));
+    sprintf(BUF, CANON_DIR "/canon_map%d.bin", k);
+    int Kfd = open(BUF, 0*O_RDONLY);
+    assert(Kfd > 0);
+    short int *Kf = Mmap(K, Bk*sizeof(K[0]), Kfd);
+    assert(Kf == K);
 }

--- a/libblant.c
+++ b/libblant.c
@@ -61,7 +61,7 @@ void BuildGraph(TINY_GRAPH* G, int Gint)
 ** Given a pre-allocated filename buffer, a 256MB aligned array K, num nodes k
 ** Mmap the canon_map binary file to the aligned array. 
 */
-void createCanonMap(char* BUF, short int *K, int k) {
+void mapCanonMap(char* BUF, short int *K, int k) {
     int Bk = (1 <<(k*(k-1)/2));
     sprintf(BUF, CANON_DIR "/canon_map%d.bin", k);
     int Kfd = open(BUF, 0*O_RDONLY);

--- a/make-subcanon-maps.c
+++ b/make-subcanon-maps.c
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
     fclose(fp_ord);
 
     //Create canon map for k-1
-    short int *Kf = createCanonMap(BUF, K, k-1);
+    createCanonMap(BUF, K, k-1);
 
     /*
         For every canonical in canonical_list

--- a/make-subcanon-maps.c
+++ b/make-subcanon-maps.c
@@ -6,11 +6,7 @@
 #include "tinygraph.h"
 #include "blant.h"
 
-static unsigned int Bk;//Bk=actual number of entries in the canon_map for given k - 1.
-
-// Here's the actual mapping from non-canonical to canonical, same argument as above wasting memory, and also mmap'd.
-// So here we are allocating 256MB x sizeof(short int) = 512MB.
-// Grand total statically allocated memory is exactly 1.25GB.
+// Here we are allocating 256MB x sizeof(short int) = 512MB for the canon map.
 static short int K[maxBk] __attribute__ ((aligned (8192)));
 
 int main(int argc, char* argv[]) {
@@ -18,7 +14,7 @@ int main(int argc, char* argv[]) {
     k=atoi(argv[1]);
     TINY_GRAPH* G = TinyGraphAlloc(k);
 
-    Bk = (1 <<((k-1)*(k-2)/2));
+    
     char BUF[BUFSIZ];
     //Create canon list for k
     sprintf(BUF, CANON_DIR "/canon_list%d.txt", k);
@@ -31,11 +27,7 @@ int main(int argc, char* argv[]) {
     fclose(fp_ord);
 
     //Create canon map for k-1
-    sprintf(BUF, CANON_DIR "/canon_map%d.bin", k-1);
-    int Kfd = open(BUF, 0*O_RDONLY);
-    assert(Kfd > 0);
-    short int *Kf = Mmap(K, Bk*sizeof(K[0]), Kfd);
-    assert(Kf == K);
+    short int *Kf = createCanonMap(BUF, K, k-1);
 
     /*
         For every canonical in canonical_list

--- a/make-subcanon-maps.c
+++ b/make-subcanon-maps.c
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
     fclose(fp_ord);
 
     //Create canon map for k-1
-    createCanonMap(BUF, K, k-1);
+    mapCanonMap(BUF, K, k-1);
 
     /*
         For every canonical in canonical_list


### PR DESCRIPTION
Should remove a little duplication.
I can't figure out a good way to move canon list code to libblant without move constructors.  The same logic is used in many files. 
Perm map is only used once.