### PR TITLE
add testConnectedComponent function; also limits tail recursion

### DIFF
--- a/blant.c
+++ b/blant.c
@@ -164,6 +164,7 @@ static SET *SampleGraphletNodeBasedExpansion(SET *V, int *Varray, GRAPH *G, int 
 #else
 	    testConnectedComponent(G, k, v1);
 	    V = SampleGraphletNodeBasedExpansion(V, Varray, G, k);
+		decrementDepth();
 	    return V;
 #endif
 	}
@@ -272,7 +273,6 @@ static SET *SampleGraphletEdgeBasedExpansion(SET *V, int *Varray, GRAPH *G, int 
 	    {
 		// We are probably in a connected component with fewer than k nodes.
 		// Test that hypothesis.
-		testConnectedComponent(G, k, v1);
 #if ALLOW_DISCONNECTED_GRAPHLETS
 		// get a new node outside this connected component.
 		// Note this will return a disconnected graphlet.
@@ -285,7 +285,10 @@ static SET *SampleGraphletEdgeBasedExpansion(SET *V, int *Varray, GRAPH *G, int 
 		    cumulative[j] = 0;
 		SetEmpty(internal);
 #else
-		return SampleGraphletEdgeBasedExpansion(V, Varray, G, k);
+		testConnectedComponent(G, k, v1);
+		V = SampleGraphletEdgeBasedExpansion(V, Varray, G, k);
+		decrementDepth();
+		return V;
 #endif
 	    }
 	}
@@ -356,7 +359,6 @@ static SET *SampleGraphletLuBressanReservoir(SET *V, int *Varray, GRAPH *G, int 
 	if(nOut ==0) // the graphlet has saturated its connected component before getting to k, start elsewhere
 	{
 		//Check if this has happened MAX_TRIES times
-		testConnectedComponent(G, k, v1);
 #if ALLOW_DISCONNECTED_GRAPHLETS
 	    if(i < k)
 	    {
@@ -369,7 +371,10 @@ static SET *SampleGraphletLuBressanReservoir(SET *V, int *Varray, GRAPH *G, int 
 	    else
 		assert(i==k); // we're done because i >= k and nOut == 0... but we shouldn't get here.
 #else
-	    return SampleGraphletLuBressanReservoir(V, Varray, G, k);
+		testConnectedComponent(G, k, v1);
+		V = SampleGraphletLuBressanReservoir(V, Varray, G, k);
+		decrementDepth();
+		return V;
 #endif
 	}
 	else

--- a/blant.h
+++ b/blant.h
@@ -34,3 +34,4 @@ void mapCanonMap(char* BUF, short int *K, int k);
 int canonListPopulate(char *BUF, int *canon_list, int k);
 char** convertToEL(char* file); // from convert.cpp
 void testConnectedComponent(GRAPH* G, int k, int v1);
+void decrementDepth();

--- a/blant.h
+++ b/blant.h
@@ -1,4 +1,5 @@
 #include "tinygraph.h"
+#include "graph.h"
 
 // This is the maximum graphlet size that BLANT supports.  Cannot be bigger than 8.
 // Currently only used to determine the amount of static memory to allocate.
@@ -8,6 +9,7 @@
 
 #define MAX_CANONICALS	12346	// This is the number of canonical graphettes for k=8
 #define MAX_ORBITS	79264	// This is the number of orbits for k=8
+#define MAX_TRIES 100		// max # of tries in cumulative sampling before giving up
 
 // BLANT represents a graphlet using one-half of the adjacency matrix (since we are assuming symmetric, undirected graphs)
 // We have a choice of using the upper or lower triangle. We prefer the lower triangle because that's what Jesse uses
@@ -21,6 +23,8 @@
 // local alignment between the nodes listed.  Listing them in the other direction doesn't seem to have much use.
 #define PERMS_CAN2NON	1
 
+#define PARANOID_ASSERTS 1	// turn on paranoid checking --- slows down execution by a factor of 2-3
+
 #define CANON_DIR "canon_maps"
 //#define CANON_DIR "/var/preserve/Graphette/canon_maps" // if you happen to put it there...
 
@@ -29,3 +33,4 @@ int TinyGraph2Int(TINY_GRAPH *g, int numNodes);
 void mapCanonMap(char* BUF, short int *K, int k);
 int canonListPopulate(char *BUF, int *canon_list, int k);
 char** convertToEL(char* file); // from convert.cpp
+void testConnectedComponent(GRAPH* G, int k, int v1);

--- a/libblant.c
+++ b/libblant.c
@@ -92,7 +92,7 @@ int canonListPopulate(char *BUF, int *canon_list, int k) {
 */
 void testConnectedComponent(GRAPH *G, int k, int v1) {
     int nodeArray[G->n], distArray[G->n];
-    int sizeOfCC = GraphBFS(G, v1, G->n, nodeArray, distArray);
+    int sizeOfCC = GraphDFS(G, v1, k, nodeArray, distArray);
 #if PARANOID_ASSERTS
 		assert(sizeOfCC < k);
 #endif

--- a/libblant.c
+++ b/libblant.c
@@ -1,6 +1,8 @@
 #include <sys/file.h>
 #include "blant.h"
 
+static int depth;
+
 // Given a TINY_GRAPH and k, return the integer ID created from one triangle (upper or lower) of the adjacency matrix.
 int TinyGraph2Int(TINY_GRAPH *g, int k)
 {
@@ -92,11 +94,14 @@ int canonListPopulate(char *BUF, int *canon_list, int k) {
 */
 void testConnectedComponent(GRAPH *G, int k, int v1) {
     int nodeArray[G->n], distArray[G->n];
-    int sizeOfCC = GraphDFS(G, v1, k, nodeArray, distArray);
+    int sizeOfCC = GraphBFS(G, v1, k, nodeArray, distArray);
 #if PARANOID_ASSERTS
 		assert(sizeOfCC < k);
 #endif
-    static int depth;
     depth++;
     assert(depth < MAX_TRIES);
+}
+
+void decrementDepth() {
+    depth--;
 }

--- a/libblant.c
+++ b/libblant.c
@@ -58,7 +58,7 @@ void BuildGraph(TINY_GRAPH* G, int Gint)
 }
 
 /*
-** Given a pre-allocated filename buffer, a 256MB aligned array K, num nodes k
+** Given a pre-allocated filename buffer of BUFSIZ, a 256MB aligned array K, num nodes k
 ** Mmap the canon_map binary file to the aligned array. 
 */
 void mapCanonMap(char* BUF, short int *K, int k) {
@@ -70,6 +70,10 @@ void mapCanonMap(char* BUF, short int *K, int k) {
     assert(Kf == K);
 }
 
+/*
+** Given a pre-allocated filename buffer of BUFSIZ, a preallocated canon list of size MAX_CANONICALS
+** Fill the buffer with the canon_list$k.txt. 
+*/
 int canonListPopulate(char *BUF, int *canon_list, int k) {
     sprintf(BUF, CANON_DIR "/canon_list%d.txt", k);
     FILE *fp_ord=fopen(BUF, "r");

--- a/libblant.c
+++ b/libblant.c
@@ -84,3 +84,19 @@ int canonListPopulate(char *BUF, int *canon_list, int k) {
     fclose(fp_ord);
     return numCanon;
 }
+
+/*
+** Given a generated Graph G, number of nodes k, and vertex index v1,
+** find the number of nodes in the connected comonent the vertex is in.
+** Also, assert that this hasn't happened MAX_TRIES times before.
+*/
+void testConnectedComponent(GRAPH *G, int k, int v1) {
+    int nodeArray[G->n], distArray[G->n];
+    int sizeOfCC = GraphBFS(G, v1, G->n, nodeArray, distArray);
+#if PARANOID_ASSERTS
+		assert(sizeOfCC < k);
+#endif
+    static int depth;
+    depth++;
+    assert(depth < MAX_TRIES);
+}


### PR DESCRIPTION
Changed node, edge, and LuBressanReservoir expansion to check if they are in a connected component and limit their tail recursion. 

SampleGraphletNodeBasedExpansion previously tracked its depth in the tail recursion but didn't check if it was in a connected component with DFS. It 'assumed' that with degree counting.

SampleGraphletEdgeBasedExpansion previously checked if it was in a connected component with DFS. It didn't track depth in tail recursion. It limited attempts to try a new node from the current connected component to 100.