### PR TITLE
Revert "add testConnectedComponent function; also limits tail recursion"

### DIFF
--- a/blant.c
+++ b/blant.c
@@ -12,6 +12,8 @@
 #include "heap.h"
 #include "blant.h"
 
+#define PARANOID_ASSERTS 1	// turn on paranoid checking --- slows down execution by a factor of 2-3
+
 // Enable the code that uses C++ to parse input files?
 #define SHAWN_AND_ZICAN 0
 static int *_pairs, _numNodes, _numEdges, _maxEdges=1024;
@@ -21,6 +23,7 @@ char **_nodeNames;
 #define SAMPLE_UNBIASED 0	// makes things REALLY REALLY slow.  Like 10-100 samples per second rather than a million.
 #define SAMPLE_NODE_EXPANSION 1	// sample using uniform node expansion; about 100,000 samples per second
 #define SAMPLE_EDGE_EXPANSION 0	// Fastest, up to a million samples per second
+#define MAX_TRIES 100		// max # of tries in cumulative sampling before giving up
 #if (SAMPLE_UNBIASED + SAMPLE_NODE_EXPANSION + SAMPLE_EDGE_EXPANSION) != 1
 #error "must choose exactly one of the SAMPLE_XXX choices"
 #endif
@@ -162,9 +165,12 @@ static SET *SampleGraphletNodeBasedExpansion(SET *V, int *Varray, GRAPH *G, int 
 	    outbound[nOut++] = j;
 	    j = 0;
 #else
-	    testConnectedComponent(G, k, v1);
+	    static int depth;
+	    // tail recursion... must terminate eventually as long as there's at least one connected component with >=k nodes.
+	    depth++;
+	    assert(depth < MAX_TRIES);
 	    V = SampleGraphletNodeBasedExpansion(V, Varray, G, k);
-		decrementDepth();
+	    depth--;
 	    return V;
 #endif
 	}
@@ -273,6 +279,11 @@ static SET *SampleGraphletEdgeBasedExpansion(SET *V, int *Varray, GRAPH *G, int 
 	    {
 		// We are probably in a connected component with fewer than k nodes.
 		// Test that hypothesis.
+		int nodeArray[G->n], distArray[G->n];
+		int sizeOfCC = GraphBFS(G, v1, G->n, nodeArray, distArray);
+#if PARANOID_ASSERTS
+		assert(sizeOfCC < k);
+#endif
 #if ALLOW_DISCONNECTED_GRAPHLETS
 		// get a new node outside this connected component.
 		// Note this will return a disconnected graphlet.
@@ -285,10 +296,7 @@ static SET *SampleGraphletEdgeBasedExpansion(SET *V, int *Varray, GRAPH *G, int 
 		    cumulative[j] = 0;
 		SetEmpty(internal);
 #else
-		testConnectedComponent(G, k, v1);
-		V = SampleGraphletEdgeBasedExpansion(V, Varray, G, k);
-		decrementDepth();
-		return V;
+		return SampleGraphletEdgeBasedExpansion(V, Varray, G, k);
 #endif
 	    }
 	}
@@ -358,7 +366,6 @@ static SET *SampleGraphletLuBressanReservoir(SET *V, int *Varray, GRAPH *G, int 
 	int candidate;
 	if(nOut ==0) // the graphlet has saturated its connected component before getting to k, start elsewhere
 	{
-		//Check if this has happened MAX_TRIES times
 #if ALLOW_DISCONNECTED_GRAPHLETS
 	    if(i < k)
 	    {
@@ -371,10 +378,7 @@ static SET *SampleGraphletLuBressanReservoir(SET *V, int *Varray, GRAPH *G, int 
 	    else
 		assert(i==k); // we're done because i >= k and nOut == 0... but we shouldn't get here.
 #else
-		testConnectedComponent(G, k, v1);
-		V = SampleGraphletLuBressanReservoir(V, Varray, G, k);
-		decrementDepth();
-		return V;
+	    return SampleGraphletLuBressanReservoir(V, Varray, G, k);
 #endif
 	}
 	else

--- a/blant.h
+++ b/blant.h
@@ -1,5 +1,4 @@
 #include "tinygraph.h"
-#include "graph.h"
 
 // This is the maximum graphlet size that BLANT supports.  Cannot be bigger than 8.
 // Currently only used to determine the amount of static memory to allocate.
@@ -9,7 +8,6 @@
 
 #define MAX_CANONICALS	12346	// This is the number of canonical graphettes for k=8
 #define MAX_ORBITS	79264	// This is the number of orbits for k=8
-#define MAX_TRIES 100		// max # of tries in cumulative sampling before giving up
 
 // BLANT represents a graphlet using one-half of the adjacency matrix (since we are assuming symmetric, undirected graphs)
 // We have a choice of using the upper or lower triangle. We prefer the lower triangle because that's what Jesse uses
@@ -23,8 +21,6 @@
 // local alignment between the nodes listed.  Listing them in the other direction doesn't seem to have much use.
 #define PERMS_CAN2NON	1
 
-#define PARANOID_ASSERTS 1	// turn on paranoid checking --- slows down execution by a factor of 2-3
-
 #define CANON_DIR "canon_maps"
 //#define CANON_DIR "/var/preserve/Graphette/canon_maps" // if you happen to put it there...
 
@@ -33,5 +29,3 @@ int TinyGraph2Int(TINY_GRAPH *g, int numNodes);
 void mapCanonMap(char* BUF, short int *K, int k);
 int canonListPopulate(char *BUF, int *canon_list, int k);
 char** convertToEL(char* file); // from convert.cpp
-void testConnectedComponent(GRAPH* G, int k, int v1);
-void decrementDepth();

--- a/libblant.c
+++ b/libblant.c
@@ -1,8 +1,6 @@
 #include <sys/file.h>
 #include "blant.h"
 
-static int depth;
-
 // Given a TINY_GRAPH and k, return the integer ID created from one triangle (upper or lower) of the adjacency matrix.
 int TinyGraph2Int(TINY_GRAPH *g, int k)
 {
@@ -60,7 +58,7 @@ void BuildGraph(TINY_GRAPH* G, int Gint)
 }
 
 /*
-** Given a pre-allocated filename buffer of BUFSIZ, a 256MB aligned array K, num nodes k
+** Given a pre-allocated filename buffer, a 256MB aligned array K, num nodes k
 ** Mmap the canon_map binary file to the aligned array. 
 */
 void mapCanonMap(char* BUF, short int *K, int k) {
@@ -72,10 +70,6 @@ void mapCanonMap(char* BUF, short int *K, int k) {
     assert(Kf == K);
 }
 
-/*
-** Given a pre-allocated filename buffer of BUFSIZ, a preallocated canon list of size MAX_CANONICALS
-** Fill the buffer with the canon_list$k.txt. 
-*/
 int canonListPopulate(char *BUF, int *canon_list, int k) {
     sprintf(BUF, CANON_DIR "/canon_list%d.txt", k);
     FILE *fp_ord=fopen(BUF, "r");
@@ -85,23 +79,4 @@ int canonListPopulate(char *BUF, int *canon_list, int k) {
     for(i=0; i<numCanon; i++) fscanf(fp_ord, "%d", &canon_list[i]);
     fclose(fp_ord);
     return numCanon;
-}
-
-/*
-** Given a generated Graph G, number of nodes k, and vertex index v1,
-** find the number of nodes in the connected comonent the vertex is in.
-** Also, assert that this hasn't happened MAX_TRIES times before.
-*/
-void testConnectedComponent(GRAPH *G, int k, int v1) {
-    int nodeArray[G->n], distArray[G->n];
-    int sizeOfCC = GraphBFS(G, v1, k, nodeArray, distArray);
-#if PARANOID_ASSERTS
-		assert(sizeOfCC < k);
-#endif
-    depth++;
-    assert(depth < MAX_TRIES);
-}
-
-void decrementDepth() {
-    depth--;
 }


### PR DESCRIPTION
Reverts waynebhayes/BLANT#8

Unfortunately causes assertion failure when calling LuBressan:

blant: libblant.c:99: testConnectedComponent: Assertion `sizeOfCC < k' failed.
