### PR TITLE
Separate sliding window initialization logic

### DIFF
--- a/libwayne/MT19937/Makefile
+++ b/libwayne/MT19937/Makefile
@@ -2,3 +2,7 @@ mt19937: MTGenerator.hpp c_code.c mt19937.cpp mt19937.h
 	gcc -c c_code.c
 	g++ -std=c++11 -c mt19937.cpp
 	g++ -o mt19937 c_code.o mt19937.o
+
+clean:
+	/bin/rm -f *.o mt19937
+	

--- a/libwayne/Makefile
+++ b/libwayne/Makefile
@@ -39,6 +39,7 @@ opt_clean:
 
 raw_clean:
 	/bin/rm -f src/*.[oa] $(LIBOUT) made
+	cd MT19937; make clean
 
 clean:
 	/bin/rm -f *.a


### PR DESCRIPTION
I separated the sliding window logic from MCMC initialization because I heard of Henry + others wishing to use sliding windows in their code. 
I also made it so "make realclean" cleans the MT19937 directory. I was failing to link because of old object files in there.

I tested these changes on my laptop + openlab and MCMC still gives the 'same' output.