### PR TITLE
Quote filename in output to allow spaces etc

### DIFF
--- a/Draw/DrawGraphette.cpp
+++ b/Draw/DrawGraphette.cpp
@@ -374,6 +374,6 @@ void writeEdgesLower(ofstream& outfile, const vector<string>& inputBitstrings, i
 
 void printGraphConversionInstruction(const string& filename) {
 	stringstream ss;
-	ss << "neato -n -Tpdf " << filename << ".dot -o " << filename << ".pdf";
+	ss << "neato -n -Tpdf \"" << filename << ".dot\" -o \"" << filename << ".pdf\"";
 	std::cout << ss.str() << std::endl;
 }


### PR DESCRIPTION
Tested with: 
Draw/graphette2dot -k 5 -d 585 -o "testing big file name" -t "testing big title"
neato -n -Tpdf "testing big file name.dot" -o "testing big file name.pdf"

[testing big file name.pdf](https://github.com/waynebhayes/BLANT/files/2955489/testing.big.file.name.pdf)
