### PR TITLE
 Add frequency display mode command line option 

### DIFF
--- a/blant.c
+++ b/blant.c
@@ -1801,6 +1801,7 @@ const char const * const USAGE = \
     "Graph must be in one of the following formats with its extension name .\n" \
           "GML (.gml) GraphML (.xml) LGF(.lgf) CSV(.csv) LEDA(.leda) Edgelist (.el) .\n" \
     "outputMode is one of: o (ODV, the default); i (indexGraphlets); g (GDV); f (graphletFrequency).\n" \
+	"-m{f}{frequencyDisplayMode} is allowed with frequencyDisplayMode being one of: i(integer or count) and d(decimal or concentration)\n" \
     "samplingMethod is one of: NBE (Node Based Expansion); EBE (Edge Based Expansion); MCMC (Markov chain Monte Carlo); RES (Lu Bressan's reservoir).\n" \
 	"displayMode controls how the graphlet is displayed: options are:\n"\
 	"\ti (integer ordinal), d(decimal), b (binary), j (JESSE), o (ORCA).\n" \

--- a/blant.c
+++ b/blant.c
@@ -1843,7 +1843,7 @@ int main(int argc, char *argv[])
 			case 'i': _freqDisplayMode = count; break;
 			case 'd': _freqDisplayMode = concentration; break;
 			case '\0': _freqDisplayMode = freq_display_mode_undef; break;
-			default: Fatal("-m%c: unknown frequency display mode;\n"
+			default: Fatal("-mf%c: unknown frequency display mode;\n"
 			"\tmodes are i=integer(count), d=decimal(concentration)", *(optarg + 1));
 			break;
 		}


### PR DESCRIPTION
I added an additional option to -mf where -mfi and -mfd output integers and decimal frequencies accordingly. If no additional character is specified, the default for each algorithm is used (MCMC -> concentration and Others -> count). 
With all the enums I'm adding for display modes, I'm considering changing them to prefixed enums as C does not have scoped enums.
Test cases (On Openlab) that demonstrate changes:
- `./blant -s MCMC -n 100000 -mf -k 3  networks/syeast.el`
    0.662320 2
    0.337680 3
- `./blant -s NBE -n 100000 -mf -k 3  networks/syeast.el`
    49168 2
    50832 3
- `./blant -s MCMC -n 100000 -mfi -k 3  networks/syeast.el`
    64031 2
    35968 3
- `./blant -s NBE -n 100000 -mfi -k 3  networks/syeast.el`
    49334 2
    50666 3
- `./blant -s MCMC -n 100000 -mfd -k 3  networks/syeast.el`
    0.653231 2
    0.346769 3
- `./blant -s NBE -n 100000 -mfd -k 3  networks/syeast.el`
    0.493730 2
    0.506270 3
- `./blant -s NBE -n 100000 -mfo -k 3  networks/syeast.el`
- User error: -mfo: unknown frequency display mode;
        modes are i=integer(count), d=decimal(concentration)

Updated Usage String:
    USAGE: blant [-r seed] [-t threads (default=1)] [-m{outputMode}] [-d{displayMode}] {-n nSamples | -c confidence -w width} {-k k} {-w windowSize} {-s samplingMethod} {graphInputFile}
    Graph must be in one of the following formats with its extension name .
    GML (.gml) GraphML (.xml) LGF(.lgf) CSV(.csv) LEDA(.leda) Edgelist (.el) .
    outputMode is one of: o (ODV, the default); i (indexGraphlets); g (GDV); f (graphletFrequency).
    -m{f}{frequencyDisplayMode} is allowed with frequencyDisplayMode being one of: i(integer or count) and d(decimal or concentration)
    samplingMethod is one of: NBE (Node Based Expansion); EBE (Edge Based Expansion); MCMC (Markov chain Monte Carlo); RES (Lu Bressan's reservoir).
    displayMode controls how the graphlet is displayed: options are:
            i (integer ordinal), d(decimal), b (binary), j (JESSE), o (ORCA).
    At the moment, nodes must be integers numbered 0 through n-1, inclusive.
    Duplicates and self-loops should be removed before calling BLANT.
    k is the number of nodes in graphlets to be sampled.    