### PR TITLE
Default frequency sampling to integer(count)

### DIFF
--- a/blant.c
+++ b/blant.c
@@ -1917,13 +1917,8 @@ int main(int argc, char *argv[])
 	}
     }
     if(_outputMode == undef) _outputMode = outputODV; // default to the same thing ORCA and Jesse us
-	if (_freqDisplayMode == freq_display_mode_undef) // Default to what makes the most sense for the sampling algorithm
-	{
-		if (_sampleMethod == SAMPLE_MCMC)
-			_freqDisplayMode = concentration;
-		else
-			_freqDisplayMode = count;
-	}
+	if (_freqDisplayMode == freq_display_mode_undef) // Default to integer(count)
+		_freqDisplayMode = count;
 
     if(numSamples!=0 && confidence>0)
 	Fatal("cannot specify both -s (sample size) and confidence interval (-w, -c) pair");


### PR DESCRIPTION
Tested on openlab.

I'm considering switching all the enums to be prefixed because I keep making more of them, it's getting a bit confusing, and my research appears to show its the alternative to C++'s scoped enums.

```
bstracy@andromeda-75:~/BLANT$ ./blant -mf -n 100000 -k 5 -s MCMC networks/syeast.el
2551 4
15140 10
8831 11
9309 14
10751 15
940 16
8077 17
24 18
840 19
12347 22
7016 23
9103 24
2626 25
81 26
613 27
2875 28
195 29
4310 30
272 31
2414 32
1676 33
```