### PR TITLE
Add AR as command line option

### DIFF
--- a/blant.c
+++ b/blant.c
@@ -1802,7 +1802,7 @@ const char const * const USAGE = \
           "GML (.gml) GraphML (.xml) LGF(.lgf) CSV(.csv) LEDA(.leda) Edgelist (.el) .\n" \
     "outputMode is one of: o (ODV, the default); i (indexGraphlets); g (GDV); f (graphletFrequency).\n" \
 	"-m{f}{frequencyDisplayMode} is allowed with frequencyDisplayMode being one of: i(integer or count) and d(decimal or concentration)\n" \
-    "samplingMethod is one of: NBE (Node Based Expansion); EBE (Edge Based Expansion); MCMC (Markov chain Monte Carlo); RES (Lu Bressan's reservoir).\n" \
+    "samplingMethod is one of: NBE (Node Based Expansion); EBE (Edge Based Expansion); MCMC (Markov chain Monte Carlo); RES (Lu Bressan's reservoir); AR (Accept-Reject).\n" \
 	"displayMode controls how the graphlet is displayed: options are:\n"\
 	"\ti (integer ordinal), d(decimal), b (binary), j (JESSE), o (ORCA).\n" \
     "At the moment, nodes must be integers numbered 0 through n-1, inclusive.\n" \
@@ -1884,6 +1884,8 @@ int main(int argc, char *argv[])
 			_sampleMethod = SAMPLE_MCMC;
 		else if (strncmp(optarg, "RES", 3) == 0)
 			_sampleMethod = SAMPLE_RESERVOIR;
+		else if (strncmp(optarg, "AR", 2) == 0)
+			_sampleMethod = SAMPLE_ACCEPT_REJECT;
 		else
 		{
 			_sampleFileName = optarg;


### PR DESCRIPTION
Sridevi requested to add AR as an option. I'm surprised it currently isn't available as a command line option but couldn't find an old commit removing it. Probably shouldn't accept this if there's a good reason.

Test Case + updated usage string:

```
 ./blant -mf -n 1000 -k 3 -s AR networks/syeast.el                                                                                               
627 2
373 3
Average number of tries per sample is 900.58
./blant
USAGE: blant [-r seed] [-t threads (default=1)] [-m{outputMode}] [-d{displayMode}] {-n nSamples | -c confidence -w width} {-k k} {-w windowSize} {-s samplingMethod} {graphInputFile}
Graph must be in one of the following formats with its extension name .
GML (.gml) GraphML (.xml) LGF(.lgf) CSV(.csv) LEDA(.leda) Edgelist (.el) .
outputMode is one of: o (ODV, the default); i (indexGraphlets); g (GDV); f (graphletFrequency).
-m{f}{frequencyDisplayMode} is allowed with frequencyDisplayMode being one of: i(integer or count) and d(decimal or concentration)
samplingMethod is one of: NBE (Node Based Expansion); EBE (Edge Based Expansion); MCMC (Markov chain Monte Carlo); RES (Lu Bressan's reservoir); AR (Accept-Reject).
displayMode controls how the graphlet is displayed: options are:
        i (integer ordinal), d(decimal), b (binary), j (JESSE), o (ORCA).
At the moment, nodes must be integers numbered 0 through n-1, inclusive.
Duplicates and self-loops should be removed before calling BLANT.
k is the number of nodes in graphlets to be sampled.
```