### PR TITLE
Change ODV output mode to only print orbits from connected graphlets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ slow-canon-maps: libwayne/made slow-canon-maps.c | blant.h libblant.o
 make-orbit-maps: libwayne/made make-orbit-maps.c | blant.h libblant.o
 	$(CC) -o $@ libblant.o make-orbit-maps.c $(LIBWAYNE)
 
-blant: libwayne/made blant.c blant.h convert.o | libwayne/MT19937/mt19937.o libblant.o 
+blant: libwayne/made blant.c blant.h convert.o libblant.o | libwayne/MT19937/mt19937.o
 	$(CC) -c blant.c $(LIBWAYNE)
 	$(CXX) -o $@ libblant.o blant.o convert.o $(LIBWAYNE) libwayne/MT19937/mt19937.o
 
@@ -47,7 +47,7 @@ synthetic: libwayne/made synthetic.c syntheticDS.h syntheticDS.c | libblant.o
 	$(CXX) -o $@ syntheticDS.o libblant.o synthetic.o $(LIBWAYNE)
 
 CC: libwayne/made CC.c convert.o | blant.h libblant.o
-	$(CXX) -o $@ libblant.o CC.o convert.o $(LIBWAYNE)
+	$(CXX) -o $@ libblant.o CC.c convert.o $(LIBWAYNE)
 
 makeEHD: libwayne/made makeEHD.c | libblant.o
 	$(CC) -c makeEHD.c $(LIBWAYNE)

--- a/blant.c
+++ b/blant.c
@@ -72,6 +72,7 @@ static unsigned int _Bk, _k; // _k is the global variable storing k; _Bk=actual 
 static int _numCanon, _canonList[MAX_CANONICALS];
 static SET *_connectedCanonicals;
 static int _numOrbits, _orbitList[MAX_CANONICALS][maxK]; // Jens: this may not be the array we need, but something like this...
+static int _orbitCanonMapping[MAX_ORBITS]; // Maps orbits to canonical (including disconnected)
 
 //windowRep global Variables
 #define WINDOW_SAMPLE_MIN 1 // Find the k-graphlet with minimal canonicalInt
@@ -1198,7 +1199,7 @@ void SetGlobalCanonMaps(void)
     _Bk = (1 <<(_k*(_k-1)/2));
     _connectedCanonicals = SetAlloc(_Bk);
     _numCanon = canonListPopulate(BUF, _canonList, _connectedCanonicals, _k);
-    _numOrbits = orbitListPopulate(BUF, _orbitList, _k);
+    _numOrbits = orbitListPopulate(BUF, _orbitList, _orbitCanonMapping, _numCanon, _k);
     mapCanonMap(BUF, _K, _k);
 	sprintf(BUF, "%s/%s/perm_map%d.bin", _BLANT_DIR, CANON_DIR, _k);
     int pfd = open(BUF, 0*O_RDONLY);

--- a/blant.c
+++ b/blant.c
@@ -1726,7 +1726,7 @@ int RunBlantFromGraph(int k, int numSamples, GRAPH *G)
         for(i=0; i<G->n; i++) {
 	    if(_supportNodeNames) printf("%s",_nodeNames[i]);
 	    else printf("%d",i);
-	    for(j=0; j<_numOrbits; j++) printf(" %lu", ODV(i,j));
+	    for(j=0; j<_numOrbits; j++) if (SetIn(_connectedCanonicals, _orbitCanonMapping[j])) printf(" %lu", ODV(i,j));
 	    printf("\n");
 	}
         break;

--- a/blant.h
+++ b/blant.h
@@ -34,5 +34,5 @@ void BuildGraph(TINY_GRAPH* G, int Gint);
 int TinyGraph2Int(TINY_GRAPH *g, int numNodes);
 void mapCanonMap(char* BUF, short int *K, int k);
 int canonListPopulate(char *BUF, int *canon_list, SET *connectedCanonicals, int k);
-int orbitListPopulate(char *BUF, int orbit_list[MAX_CANONICALS][maxK], int k);
+int orbitListPopulate(char *BUF, int orbit_list[MAX_CANONICALS][maxK],  int orbit_canon_mapping[MAX_ORBITS], int numCanon, int k);
 char** convertToEL(char* file); // from convert.cpp

--- a/libblant.c
+++ b/libblant.c
@@ -86,13 +86,13 @@ int canonListPopulate(char *BUF, int *canon_list, SET *connectedCanonicals, int 
     return numCanon;
 }
 	
-int orbitListPopulate(char *BUF, int orbit_list[MAX_CANONICALS][maxK], int k) {
+int orbitListPopulate(char *BUF, int orbit_list[MAX_CANONICALS][maxK], int orbit_canon_mapping[MAX_ORBITS], int numCanon, int k) {
     sprintf(BUF, "%s/%s/orbit_map%d.txt", _BLANT_DIR, CANON_DIR, k);
     FILE *fp_ord=fopen(BUF, "r");
     if(!fp_ord) Fatal("cannot find %s\n", BUF);
     int numOrbit, i, j;
     fscanf(fp_ord, "%d",&numOrbit);
-    for(i=0; i<numOrbit; i++) for(j=0; j<k; j++)fscanf(fp_ord, "%d", &orbit_list[i][j]);
+    for(i=0; i<numCanon; i++) for(j=0; j<k; j++) { fscanf(fp_ord, "%d", &orbit_list[i][j]); orbit_canon_mapping[orbit_list[i][j]] = i; }
     fclose(fp_ord);
     return numOrbit;
 }


### PR DESCRIPTION
I also decided blant should be recompiled with changes to libblant.o

Before:
```
for k in 3 4 5; do ./blant -mo -s NBE -n 1000000 -k $k networks/syeast.el | head -n 5; done
0 0 0 0 522 197 2041
1 0 0 0 541 161 2044
2 0 0 0 403 419 3518
3 0 0 0 398 136 3638
4 0 0 0 521 696 1363
0 0 0 0 0 0 0 93 4 0 0 0 144 141 238 629 172 3 56 213 1830
1 0 0 0 0 0 0 119 0 0 0 0 103 153 235 721 109 1 51 239 1829
2 0 0 0 0 0 0 3 29 0 0 0 59 204 269 565 356 3 45 660 3672
3 0 0 0 0 0 0 14 4 0 0 0 86 66 115 784 65 0 119 396 3791
4 0 0 0 0 0 0 135 187 0 0 0 159 462 284 265 507 0 4 546 923
0 0 0 0 0 0 0 0 0 0 22 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 48 28 8 21 167 1 0 0 0 0 0 34 32 45 103 20 41 4 0 4 0 49 23 20 4 0 0 1 3 0 0 0 0 39 110 116 98 51 10 126 3 127 741 121 159 0 0 0 2 2 0 12 0 0 3 0 0 145 149 0 0 22 184 1442
1 0 0 0 0 0 0 0 0 0 25 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 49 29 33 0 56 174 0 0 0 0 0 0 27 16 17 85 37 20 2 0 0 0 83 15 38 0 0 0 0 0 0 0 0 0 27 80 82 66 25 1 173 0 165 770 78 201 0 0 0 1 0 0 17 8 0 0 0 0 130 160 0 3 26 213 1422
2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 5 1 1 25 0 15 12 0 0 0 0 0 12 10 20 9 20 40 0 0 0 1 6 0 46 73 0 0 0 44 0 0 0 0 44 121 175 165 2 7 236 13 244 783 284 195 3 0 0 6 1 12 35 16 0 0 0 22 59 515 0 0 6 770 3252
3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 5 3 0 4 2 31 1 0 0 0 0 0 12 0 1 4 31 5 0 0 0 0 2 26 64 3 0 0 2 14 0 0 0 0 51 218 16 54 8 13 145 1 127 1148 12 179 0 0 4 0 0 19 15 3 0 0 0 0 301 206 0 0 61 601 3469
4 0 0 0 0 0 0 0 0 0 22 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 61 35 123 158 90 53 139 0 0 0 0 0 36 23 93 64 4 69 0 0 0 0 54 0 75 111 0 0 0 131 0 0 0 0 41 109 242 214 42 4 175 5 232 240 335 40 0 0 0 0 0 0 0 41 0 0 0 0 9 389 0 1 0 312 535

```
After:
```
for k in 3 4 5; do ./blant -mo -s NBE -n 1000000 -k $k networks/syeast.el | head -n 5; done
0 504 203 1934
1 526 162 1945
2 413 463 3624
3 416 144 3637
4 563 747 1365
0 103 5 154 171 178 696 138 1 60 189 1815
1 108 0 93 127 233 749 132 0 58 220 1857
2 2 32 70 240 267 625 365 2 50 677 3633
3 21 4 87 64 130 821 53 0 140 430 3657
4 155 191 161 391 296 292 507 0 6 563 902
0 20 0 32 46 39 9 28 167 1 33 26 56 107 29 52 1 1 1 0 39 23 16 15 0 1 3 1 50 113 124 85 48 9 124 6 129 772 109 155 0 0 0 1 3 0 8 0 0 2 0 0 138 106 3 0 20 187 1457
1 23 0 45 18 43 0 67 197 0 23 5 31 103 47 36 0 1 0 0 67 16 30 0 0 0 0 0 31 104 97 77 21 2 169 1 141 807 91 174 2 0 0 0 0 2 11 11 0 0 0 0 122 150 0 3 15 201 1433
2 0 3 1 4 3 19 0 10 7 12 10 10 13 11 34 0 0 0 0 7 0 61 51 0 0 0 32 33 133 140 160 0 6 251 11 249 864 273 168 2 0 2 7 0 9 34 25 0 0 0 19 66 536 0 0 5 809 3202
3 0 0 8 6 0 4 2 51 2 9 9 2 3 29 10 0 0 0 0 0 31 58 4 0 0 6 9 48 175 41 41 6 16 167 0 105 1172 15 197 0 0 2 0 0 15 14 6 0 0 0 1 255 160 0 0 53 618 3421
4 17 32 66 31 108 169 75 50 155 33 28 72 76 7 55 0 0 0 0 57 0 58 109 0 0 0 124 32 79 204 203 49 3 182 2 237 220 331 32 0 0 0 0 0 2 3 39 0 0 0 0 6 394 0 1 0 314 539
```