### PR TITLE
Add ordinal output mode to graphette2dot

### DIFF
--- a/Draw/DrawGraphette.cpp
+++ b/Draw/DrawGraphette.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <cstdio>
 #include <math.h>
+#include <unistd.h>
 #include "graphette2dotutils.h"
 
 using std::cout;
@@ -19,39 +20,47 @@ using std::ofstream;
 using std::ifstream;
 using std::vector;
 
-void parseInput(int argc, char* argv[], int& numNodes, vector<string>& inputBitstrings, string& outputFile, string& namesFile, bool& isUpper, string& graphTitle, int& edgewidth);	
+void parseInput(int argc, char* argv[], int& k, vector<string>& inputBitstrings, string& outputFile, string& namesFile, bool& isUpper, string& graphTitle, int& edgewidth);
 void printUsage();
 void printHelp();
-string toBitString(unsigned long long inputDecimalNum, int numNodes);
-string appendLeadingZeros(const string& inputBitstring, int numNodes);
+string toBitString(unsigned long long inputDecimalNum, int k);
+string appendLeadingZeros(const string& inputBitstring, int k);
 
-void createDotfileFromBit(int numNodes, const vector<string>& inputBitstring, const string& outputFile, const string& namesFile, bool isUpper, const string& graphTitle, int edgewidth);
-string getPos(int i, int numNodes);
-void writeEdges(ofstream& outfile, const vector<string>& inputBitstrings, int numNodes, bool isUpper, int edgewidth);
-void writeEdgesUpper(ofstream& outfile, const vector<string>& inputBitstrings, int numNodes, int edgewidth);
-void writeEdgesLower(ofstream& outfile, const vector<string>& inputBitstrings, int numNodes, int edgewidth);
+void createDotfileFromBit(int k, const vector<string>& inputBitstring, const string& outputFile, const string& namesFile, bool isUpper, const string& graphTitle, int edgewidth);
+string getPos(int i, int k);
+void writeEdges(ofstream& outfile, const vector<string>& inputBitstrings, int k, bool isUpper, int edgewidth);
+void writeEdgesUpper(ofstream& outfile, const vector<string>& inputBitstrings, int k, int edgewidth);
+void writeEdgesLower(ofstream& outfile, const vector<string>& inputBitstrings, int k, int edgewidth);
 void printGraphConversionInstruction(const string& fileName);
 
+//Functions from libwayne and libblant.c
+extern "C" {
+	struct SET;
+	SET *SetAlloc(unsigned int n);
+    int canonListPopulate(char *BUF, int *canon_list, SET *connectedCanonicals, int k);
+}
+
 const int RADIUS_SCALING = 25;
-const string USAGE = "USAGE: ./graphette2dot <-k number_of_nodes> <-b bitstring | -d decimal_representation> <-o output_filename> [-n input_filename] [-u | -l] [-t title] [-ew edge width] -h for verbose help\n";
+const string USAGE = "USAGE: graphette2dot <-k number_of_nodes> <-b bitstring | -d decimal_representation | -i lower_ordinal> <-o output_filename> [-n input_filename] [-u | -l] [-t title] [-e edge width] -h for verbose help\n";
 const string NODE_ARGS = "shape = \"none\", fontsize = 24.0";
 const string TITLE_ARGS = "fontsize = 24.0";
 const string DECIMAL_INPUT_WARNING = "Warning. Decimal input was used with k > 11. Edge information may have been lost.\n";
 const double PI  =3.141592653589793238463;
 const vector<string> COLORS = {"black", "red", "lawngreen", "orange", "blue", "yellow", "indigo"};
+const int DEFAULT_EDGE_WIDTH = 1;
 
 int main(int argc, char* argv[]) {
-	int numNodes = 0;
+	int k = 0;
 	vector<string> inputBitstrings;
 	string outputFile = "", namesFile = "", graphTitle = "";
-	int edgewidth = 1;
+	int edgewidth = DEFAULT_EDGE_WIDTH;
 	//Defaults to lower row major bitstring/decimal interpretation
 	bool isUpper = false;
 
 	//Parses input passing variables by reference.
-	parseInput(argc, argv, numNodes, inputBitstrings, outputFile, namesFile, isUpper, graphTitle, edgewidth);
+	parseInput(argc, argv, k, inputBitstrings, outputFile, namesFile, isUpper, graphTitle, edgewidth);
 
-	createDotfileFromBit(numNodes, inputBitstrings, outputFile, namesFile, isUpper, graphTitle, edgewidth);
+	createDotfileFromBit(k, inputBitstrings, outputFile, namesFile, isUpper, graphTitle, edgewidth);
 
 	printGraphConversionInstruction(outputFile);
 
@@ -63,138 +72,160 @@ int main(int argc, char* argv[]) {
  * Doesn't allow for repeated inputs.
  * Prints usage and exits if invalid input is passed.
  * */
-void parseInput(int argc, char* argv[], int& numNodes, vector<string>& inputBitstrings, string& outputFile, string& namesFile, bool& isUpper, string& graphTitle, int& edgewidth) {
-	bool k = false, input = false, o = false, n = false, matrixType = false, title = false;
-	unsigned long long inputDecimalNum = 0;	
-	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-k") == 0) {
-			if (k) {
+void parseInput(int argc, char* argv[], int& k, vector<string>& inputBitstrings, string& outputFile, string& namesFile, bool& isUpper, string& graphTitle, int& edgewidth) {
+	bool input = false, matrixType = false;
+	unsigned long long inputDecimalNum = 0;
+	int opt;
+	vector<unsigned long long> ordinals;
+
+	while((opt = getopt(argc, argv, "k:b:d:i:o:t:e:nhul")) != -1)
+    {
+		switch(opt)
+		{
+		case 'k':
+			if (k > 0) {
 				cerr << "Only one k is allowed\n";
 				printUsage();
 			}
-			k = true;
-
-			if (i + 1 >= argc) {
-				cerr << "No following argument to " << argv[i] << '\n';
-				printUsage();				
-			}
-
-			numNodes = atoi(argv[i + 1]);
-			
-			if (numNodes == 0) {
-				cerr << "Must have at least one node in graph.\n";
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
 				printUsage();
 			}
-			i++;
-		}
-		else if (strcmp(argv[i], "-b") == 0) {
+			k = atoi(optarg);
+			break;
 
+		case 'b':
 			input = true;
-			
-			if (i + 1 >= argc) {
-				cerr << "No following argument to " << argv[i] << '\n';
-				printUsage();				
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
+				printUsage();
 			}
+			inputBitstrings.push_back(optarg);
+			break;
 
-			inputBitstrings.push_back(argv[i + 1]);
-			i++;
-		}
-		else if (strcmp(argv[i], "-d") == 0) {
+		case 'd':
 			input = true;
-
-			if (i + 1 >= argc) {
-				cerr << "No following argument to " << argv[i] << '\n';
-				printUsage();				
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
+				printUsage();
 			}
+			inputDecimalNum = std::stoull(optarg);
+			inputBitstrings.push_back(toBitString(inputDecimalNum, k));
 
-			inputDecimalNum = std::stoull(argv[i + 1]);
-			inputBitstrings.push_back(toBitString(inputDecimalNum, numNodes));
-
-			if (numNodes > 11)
+			if (k > 11)
 				cerr << DECIMAL_INPUT_WARNING;
+			break;
 
-			i++;
-		}
-		else if (strcmp(argv[i], "-o") == 0) {
-			if (o) {
+		case 'i':
+			input = true;
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
+				printUsage();
+			}
+			ordinals.push_back(std::stoull(optarg));
+			break;
+
+		case 'o':
+			if (!outputFile.empty()) {
 				cerr << "Only one output file is allowed.\n";
 				printUsage();
 			}
-			o = true;
-
-			if (i + 1 >= argc) {
-				cerr << "No following argument to " << argv[i] << '\n';
-				printUsage();				
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
+				printUsage();
 			}
+			outputFile = optarg;
+			break;
 
-			outputFile = argv[i + 1];
-			i++;
-		}
-		else if (strcmp(argv[i], "-n") == 0) {
-			if (n) {
+		case 't':
+			if (!graphTitle.empty()) {
+				cerr << "Only one title allowed.\n";
+				printUsage();
+			}
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
+				printUsage();
+			}
+			graphTitle = optarg;
+			break;
+
+		case 'e':
+			if (edgewidth != DEFAULT_EDGE_WIDTH) {
+				cerr << "Only one edge width allowed.\n";
+				printUsage();
+			}
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
+				printUsage();
+			}
+			edgewidth = atoi(optarg);
+			break;
+		case 'n':
+			if (!namesFile.empty()) {
 				cerr << "Only one names file is allowed.\n";
 				printUsage();
 			}
-			n = true;
-
-			if (i + 1 >= argc) {
-				cerr << "No following argument to " << argv[i] << '\n';
-				printUsage();				
+			if (!*(optarg)) {
+				cerr << "No following argument to " << opt << '\n';
+				printUsage();
 			}
+			namesFile = optarg;
+			break;
 
-			namesFile = argv[i + 1];
-			i++;
-		} else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+		case 'h':
 			printHelp();
-		} else if (strcmp(argv[i], "-u") == 0) {
+			break;
+
+		case 'u':
 			if (matrixType) {
 				cerr << "Only one matrix type allowed.\n";
 				printUsage();
 			}
 			isUpper = true;
 			matrixType = true;
-		} else if (strcmp(argv[i], "-l") == 0) {
+			break;
+
+		case 'l':
 			if (matrixType) {
 				cerr << "Only one matrix type allowed.\n";
 				printUsage();
 			}
 			isUpper = false;
 			matrixType = true;
-		} else if (strcmp(argv[i], "-t") == 0) {
-			if (title) {
-				cerr << "Only one title allowed.\n";
-				printUsage();
-			}
+			break;
 
-			title = true;
-
-			if (i + 1 >= argc) {
-				cerr << "No following argument to " << argv[i] << '\n';
-				printUsage();				
-			}
-
-			graphTitle = argv[i + 1];
-			i++;
-		} else if (strcmp(argv[i], "-ew") == 0) {
-			if (i + 1 >= argc) {
-				cerr << "No following argument to " << argv[i] << '\n';
-				printUsage();				
-			}
-			edgewidth = atoi(argv[i+1]);
-			i++;
-		}
-		else {
-			cerr << "Unrecognized argument: " << argv[i] << "\n";
+		default:
+			cerr << "Unrecognized argument: " << opt << "\n";
 			printUsage();
 		}
 	}
 
 	//Check if k, input data, and output file were selected
-	if (!(k && input && o))
+	if (!(k > 0 && input && outputFile.size() > 0))
 		printUsage();
 
+	if (!ordinals.empty()) {
+		if (k < 3 || k > 8) {
+			cerr << "Ordinal input is only allowed for k between 3 and 8 (inclusive)\n";
+			exit(EXIT_FAILURE);
+		}
+		isUpper = false;
+		char BUF[BUFSIZ];
+		int _canonList[12346];
+		unsigned _Bk = (1 <<(k*(k-1)/2));
+		SET *_connectedCanonicals = SetAlloc(_Bk);
+		int _numCanon = canonListPopulate(BUF, _canonList, _connectedCanonicals, k);
+		for (auto ordinal : ordinals) {
+			if (ordinal < 0 || ordinal > _numCanon) {
+				cerr << "Ordinal for k: " << k << " must be between 0 and " << _numCanon << '\n';
+				exit(EXIT_FAILURE);
+			}
+			inputBitstrings.push_back(toBitString(_canonList[ordinal], k));
+		}
+	}
+
 	for (string& bitstring : inputBitstrings) {
-		bitstring = appendLeadingZeros(bitstring, numNodes);
+		bitstring = appendLeadingZeros(bitstring, k);
 	}
 }
 
@@ -209,15 +240,15 @@ void printHelp() {
 			  << "You must specify the number of nodes with -k\n"
 			  << "Currently number of nodes is limited to 11 if decimal input is used\n"
 			  << "This is because k=12 requires 66 bits to store the decimal input\n"
-			  << "You must specify at least one bitstring or a decimal input with -b or -d\n"
-			  << "-u and -l specify if all input is upper or lower triangular row major\n"
+			  << "You must specify at least one bitstring, decimal, or ordinal input with -b -d or -i respectively\n"
+			  << "-u and -l specify if all input is upper or lower triangular row major. Lower is assumed for ordinal input.\n"
 			  << "Lower triangular row major is assumed\n"
 			  << "You must specify an output file name with -o\n"
 			  << "Please do not include file extension for output. The program with generate a .dot\n"
 			  << "If no names file is selected, nodes will be named 0, 1, ...., (k-1)\n"
 			  << "Names file parsing assumes one name per line\n"
 			  << "You may specify a title with -t\n"
-			  << "You may specify an edge width with -ew. 1 is default\n"
+			  << "You may specify an edge width with -e. 1 is default\n"
 			  << "If less names than nodes, additional nodes will be labeled by their index #\n"
 			  << "If more names than nodes, additional names will be ignored\n";
 	exit(EXIT_SUCCESS);
@@ -230,14 +261,14 @@ void printHelp() {
  * extra names become isolated nodes and additional nodes aren't labeled.
  * Then the edges are written to the file.
  * */
-void createDotfileFromBit(int numNodes, const vector<string>& inputBitstrings, const string& outputFile, const string& namesFile, bool isUpper, const string& graphTitle, int edgewidth) {
-	int finalBitstringSize = (numNodes * (numNodes - 1)) / 2;
+void createDotfileFromBit(int k, const vector<string>& inputBitstrings, const string& outputFile, const string& namesFile, bool isUpper, const string& graphTitle, int edgewidth) {
+	int finalBitstringSize = (k * (k - 1)) / 2;
 	int size;
 	for (string inputBitstring : inputBitstrings) {
 		size = inputBitstring.size();
 		if (finalBitstringSize != size) {
 			cerr << "Input size does not match number of nodes.\n"
-				<< "Expected Bitstring Size given k = " << numNodes << " is:  "
+				<< "Expected Bitstring Size given k = " << k << " is:  "
 				<< finalBitstringSize << "\nInput Bitstring Size: " << size << "\n";
 			exit(EXIT_FAILURE);
 		}
@@ -260,20 +291,20 @@ void createDotfileFromBit(int numNodes, const vector<string>& inputBitstrings, c
 		infile.open(namesFile);
 		if (infile) {
 			string nodeName;
-			while (std::getline(infile, nodeName) && i < numNodes) {
-				outfile << 'n' << i << " [label=\"" << nodeName << "\", pos=\"" << getPos(i, numNodes) << "!\"" << NODE_ARGS << ";]\n";
+			while (std::getline(infile, nodeName) && i < k) {
+				outfile << 'n' << i << " [label=\"" << nodeName << "\", pos=\"" << getPos(i, k) << "!\"" << NODE_ARGS << ";]\n";
 				i++;
 			}
-			if (i < numNodes) {
+			if (i < k) {
 				cerr << "Warning: Less nodes in names file than -k.\n"
-					 << "Number of nodes: " << numNodes << " Names file number of nodes: " << i << "\n";
+					 << "Number of nodes: " << k << " Names file number of nodes: " << i << "\n";
 			}
 
 			while (std::getline(infile, nodeName))
 				i++;
-			if (i > numNodes) {
+			if (i > k) {
 				cerr << "Warning: More nodes in names file than -k.\n"
-			         << "Number of nodes: " << numNodes << " Names file number of nodes: " << i << "\n";								
+			         << "Number of nodes: " << k << " Names file number of nodes: " << i << "\n";								
 			}
 
 			infile.close();
@@ -281,12 +312,12 @@ void createDotfileFromBit(int numNodes, const vector<string>& inputBitstrings, c
 			cerr << "Could not open name file\n";
 		}
 	}
-	while (i < numNodes) {
-		outfile << 'n' << i << "[label=\"" << i << "\", pos=\"" << getPos(i, numNodes) <<  "!\"" << NODE_ARGS << "]\n";
+	while (i < k) {
+		outfile << 'n' << i << "[label=\"" << i << "\", pos=\"" << getPos(i, k) <<  "!\"" << NODE_ARGS << "]\n";
 		i++;
 	}
 
-	writeEdges(outfile, inputBitstrings, numNodes, isUpper, edgewidth);
+	writeEdges(outfile, inputBitstrings, k, isUpper, edgewidth);
 	if (graphTitle != "") {
 		outfile << "labelloc=\"b\";\n"
 				<< "label=\"" << graphTitle << "\"\n"
@@ -296,22 +327,22 @@ void createDotfileFromBit(int numNodes, const vector<string>& inputBitstrings, c
 	outfile.close();
 }
 
-string getPos(int i, int numNodes) {
+string getPos(int i, int k) {
 	stringstream ss;
-	ss << RADIUS_SCALING * numNodes * cos(PI /2 - (2 * PI / numNodes * i)) << ", " << RADIUS_SCALING * numNodes * sin(PI / 2 - (2 * PI / numNodes * i));
+	ss << RADIUS_SCALING * k * cos(PI /2 - (2 * PI / k * i)) << ", " << RADIUS_SCALING * k * sin(PI / 2 - (2 * PI / k * i));
 	return ss.str();
 }
 
 //Wrapper function to choose edge writing function based on matrix representation.
-void writeEdges(ofstream& outfile, const vector<string>& inputBitstrings, int numNodes, bool isUpper, int edgewidth) {
+void writeEdges(ofstream& outfile, const vector<string>& inputBitstrings, int k, bool isUpper, int edgewidth) {
 	if (isUpper)
-		writeEdgesUpper(outfile, inputBitstrings, numNodes, edgewidth);
+		writeEdgesUpper(outfile, inputBitstrings, k, edgewidth);
 	else
-		writeEdgesLower(outfile, inputBitstrings, numNodes, edgewidth);
+		writeEdgesLower(outfile, inputBitstrings, k, edgewidth);
 }
 
 //Assuming row major
-void writeEdgesUpper(ofstream& outfile, const vector<string>& inputBitstrings, int numNodes, int edgewidth) {
+void writeEdgesUpper(ofstream& outfile, const vector<string>& inputBitstrings, int k, int edgewidth) {
 	size_t size = inputBitstrings[0].size();
 	int i = 0, j = 1, color = 0;
 	string penwidth = "";
@@ -336,7 +367,7 @@ void writeEdgesUpper(ofstream& outfile, const vector<string>& inputBitstrings, i
 
 		//iterate through pretend adjecency matrix
 		j++;
-		if (j == numNodes) {
+		if (j == k) {
 			i++;
 			j = i + 1;
 		}
@@ -344,7 +375,7 @@ void writeEdgesUpper(ofstream& outfile, const vector<string>& inputBitstrings, i
 }
 
 //Assuming row major
-void writeEdgesLower(ofstream& outfile, const vector<string>& inputBitstrings, int numNodes, int edgewidth) {
+void writeEdgesLower(ofstream& outfile, const vector<string>& inputBitstrings, int k, int edgewidth) {
 	size_t size = inputBitstrings[0].size();
 	unsigned int i = 1, j = 0, color = 0;
 	string penwidth = "";

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ compute-alphas-NBE: libwayne/made compute-alphas-NBE.c | libblant.o
 compute-alphas-MCMC: libwayne/made compute-alphas-MCMC.c | libblant.o
 	$(CC) -Wall -O3 -o $@ compute-alphas-MCMC.c libblant.o $(LIBWAYNE)
 
-Draw/graphette2dot: Draw/DrawGraphette.cpp Draw/graphette2dotutils.h
-	$(CXX) -std=c++11 Draw/DrawGraphette.cpp -o $@
+Draw/graphette2dot: libwayne/made Draw/DrawGraphette.cpp Draw/graphette2dotutils.h | blant.h libblant.o
+	$(CXX) -std=c++11 Draw/DrawGraphette.cpp libblant.o -o $@ $(LIBWAYNE)
 
 make-subcanon-maps: libwayne/made make-subcanon-maps.c | libblant.o
 	$(CC) -Wall -o $@ make-subcanon-maps.c libblant.o $(LIBWAYNE)


### PR DESCRIPTION
## Summary:
Just like with blant, I added an "i" opt argument for ordinal value.
I also changed the code to use getopt instead of my sphagetti.
I changed -ew to -e (edge width) because I didn't want to learn getopt_long. 
## Example:
```
Draw/graphette2dot -k 3 -i 3 -o test -e 4     
neato -n -Tpng "test.dot" -o "test.png" 
```
![test](https://user-images.githubusercontent.com/16947100/58769032-f6c0f300-8557-11e9-908a-17a755831258.png)

## Updated Usage:

> USAGE: graphette2dot <-k number_of_nodes> <-b bitstring | -d decimal_representation | -i lower_ordinal> <-o output_filename> [-n input_filename] [-u | -l] [-t title] [-e edge width] -h for verbose help
> You must specify the number of nodes with -k
> Currently number of nodes is limited to 11 if decimal input is used
> This is because k=12 requires 66 bits to store the decimal input
> You must specify at least one bitstring, decimal, or ordinal input with -b -d or -i respectively
> -u and -l specify if all input is upper or lower triangular row major. Lower is assumed for ordinal input.
> Lower triangular row major is assumed
> You must specify an output file name with -o
> Please do not include file extension for output. The program with generate a .dot
> If no names file is selected, nodes will be named 0, 1, ...., (k-1)
> Names file parsing assumes one name per line
> You may specify a title with -t
> You may specify an edge width with -e. 1 is default
> If less names than nodes, additional nodes will be labeled by their index #
> If more names than nodes, additional names will be ignored