### PR TITLE
Change compute-alphas to output to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,10 @@ canon_maps/EdgeHammingDistance%.txt: makeEHD | canon_maps/canon_list%.txt canon_
 	if [ -f canon_maps.correct/EdgeHammingDistance$*.txt.xz ]; then echo "EdgeHammingDistance8.txt takes weeks to generate, and 7 can't be done on a 32-bit machine; uncompressing instead"; unxz < canon_maps.correct/EdgeHammingDistance$*.txt.xz > $@ && touch $@; else ./makeEHD $* > $@; fi
 
 canon_maps/alpha_list_nbe%.txt: compute-alphas-NBE canon_maps/canon_list%.txt
-	./compute-alphas-NBE $*
+	./compute-alphas-NBE $* > $@
 
 canon_maps/alpha_list_mcmc%.txt: compute-alphas-MCMC | canon_maps/canon_list%.txt
-	if [ -f canon_maps.correct/alpha_list_mcmc$*.txt ]; then echo "computing MCMC alphas for k=$* takes days to just copy it"; cp -p canon_maps.correct/alpha_list_mcmc$*.txt canon_maps/ && touch $@; else ./compute-alphas-MCMC $*; fi
+	if [ -f canon_maps.correct/alpha_list_mcmc$*.txt ]; then echo "computing MCMC alphas for k=$* takes days to just copy it"; cp -p canon_maps.correct/alpha_list_mcmc$*.txt canon_maps/ && touch $@; else ./compute-alphas-MCMC $* > $@; fi
 
 .INTERMEDIATE: .created-magic-tables .created-subcanon-maps
 subcanon_maps: $(subcanon_txts) ;

--- a/compute-alphas-MCMC.c
+++ b/compute-alphas-MCMC.c
@@ -116,7 +116,9 @@ int main(int argc, char* argv[]) {
     char BUF[BUFSIZ];
     TINY_GRAPH *gk = TinyGraphAlloc(k);
 	TINY_GRAPH *gd = TinyGraphAlloc(mcmc_d);
-    int numCanon = canonListPopulate(BUF, _canonList, NULL, k);
+	int _Bk = (1 <<(k*(k-1)/2));
+    SET* _connectedCanonicals = SetAlloc(_Bk);
+    int numCanon = canonListPopulate(BUF, _canonList, _connectedCanonicals, k);
     
     L = k - mcmc_d  + 1;
     unsigned combinArrayD[mcmc_d]; //Used to hold combinations of d graphlets from our k graphlet
@@ -126,21 +128,17 @@ int main(int argc, char* argv[]) {
 	for (i = 0; i < numCanon; i++) {
 		BuildGraph(gk, _canonList[i]);
 		TinyGraphEdgesAllDelete(gd);
-		if (TinyGraphDFSConnected(gk, 0)) {
+		if (SetIn(_connectedCanonicals, i)) {
 			_alphaList[i] = ComputeAlpha(gk, gd, combinArrayD, combinArrayL, k, L);
 		}
 		else _alphaList[i] = 0; // set to 0 if unconnected graphlet
 	}
 
-    sprintf(BUF, CANON_DIR "/alpha_list_mcmc%d.txt", k);
-    FILE *fp=fopen(BUF, "w");
-    assert(fp);
-	fprintf(fp, "%d\n", numCanon);
+    printf("%d\n", numCanon);
 	for (i = 0; i < numCanon; i++) {
-		fprintf(fp, "%d ", _alphaList[i]);
+		printf("%d ", _alphaList[i]);
 	}
-	fputc('\n', fp);
-    fclose(fp);
+	printf("\n");
 
 	TinyGraphFree(gk);
 	TinyGraphFree(gd);

--- a/compute-alphas-NBE.c
+++ b/compute-alphas-NBE.c
@@ -69,21 +69,20 @@ int main(int argc, char* argv[]) {
 	int i;
 	for (i = 0; i < numCanon; i++) {
 		BuildGraph(g, _canonList[i]);
-        if (!TinyGraphDFSConnected(g, 0))
+        if (!SetIn(_connectedCanonicals, i))
             _alphaList[i] = 0;
 		else 
             _alphaList[i] = ComputeAlphaNode(g, k);
 	}
 
-    sprintf(BUF, CANON_DIR "/alpha_list_nbe%d.txt", k);
-    FILE *fp=fopen(BUF, "w");
-    assert(fp);
-	fprintf(fp, "%d\n", numCanon);
+	printf("%d\n", numCanon);
 	for (i = 0; i < numCanon; i++) {
-		fprintf(fp, "%d ", _alphaList[i]);
+		printf("%d ", _alphaList[i]);
 	}
-	fputc('\n', fp);
-    fclose(fp);
+	printf("\n");
+
+    TinyGraphFree(g);
+	SetFree(_connectedCanonicals);
 
     return 0;
 }


### PR DESCRIPTION
## Summary:
Refactored compute-alphas executables to output to stdout like the rest of the repo.
Also changed them to use the connected value from the canon_list.txt files.

## Testing:
```for k in 3 4 5 6 7 8; do diff canon_maps/alpha_list_nbe$k.txt canon_maps.correct/alpha_list_nbe$k.txt; diff canon_maps/alpha_list_mcmc$k.txt canon_maps.correct/alpha_list_mcmc$k.txt; done```
(No output)
