### PR TITLE
updated windowRep reg-test & used actual node names for windowRep

### DIFF
--- a/blant.c
+++ b/blant.c
@@ -1859,13 +1859,12 @@ void ProcessWindowRep(int *VArray, int windowRepInt) {
             _graphletCount[windowRepInt] += _numWindowRep;
             break;
         case indexGraphlets:
-            for(i=0; i<_windowSize; i++) printf("%i ",VArray[i]); 
+            for(i=0; i<_windowSize; i++)  printf("%s ", _nodeNames[VArray[i]]);
             printf("\n%i %i\n", windowRepInt, _numWindowRep);
-//          printf("\n%i\n", windowRepInt)
             for(i=0; i<_numWindowRep; i++)
             {
                 for(j=0; j<_k; j++)
-                    printf("%i ", _windowReps[i][j]); 
+                    printf("%s ", _nodeNames[_windowReps[i][j]]);
                 printf("\n");
             }
             break;

--- a/regression-tests/windowRepTest/windowRepFreq.sh
+++ b/regression-tests/windowRepTest/windowRepFreq.sh
@@ -8,10 +8,16 @@ if ! [ -d $TEST_DIR ]; then
     exit 1
 fi
 
+remove_temp_file () {
+    rm -rf $TEST_DIR/.regression_test_out.txt
+    rm -rf $TEST_DIR/.regression_test_error.txt
+}
+
 #Can change the parameter later
 w=20
 k=7
 n=5
+max_depth_attempt=10
 declare -a sampleName=("MCMC" "NBE")
 declare -a methodName=("MIN" "MAX" "DMIN" "DMAX" "LFMIN" "LFMAX")
 declare -a fnames=("SCerevisiae.el" "AThaliana.el" "CElegans.el")
@@ -27,21 +33,41 @@ do
                 echo "Cannot find $f in the networks folder" >&2
                 exit 1
             fi
+
             cmd="./blant -k$k -w$w -p$m -s$s -mf -n$n networks/$f"
-            numUniqRep=`$cmd | awk '{if($1 != 0) print $2}' | wc -l`
+            `$cmd 1>$TEST_DIR/.regression_test_out.txt 2>$TEST_DIR/.regression_test_error.txt`
+
+            depth_attempt=0
+            while [ `grep 'Assertion \`depth++ < \| Assertion \`++numTries <' $TEST_DIR/.regression_test_error.txt | wc -l` -gt 0 ] && [ $depth_attempt -lt $max_depth_attempt ]
+            do
+                `$cmd 1>$TEST_DIR/.regression_test_out.txt 2>$TEST_DIR/.regression_test_error.txt`
+                depth_attempt=$((depth_attempt + 1))
+            done
+
+            if [ $depth_attempt -eq $max_depth_attempt ]; then
+                echo "Error:  Window Sampling Failed. Increase MAX_TRIES in BLANT and try again"
+                echo "cmd:  " $cmd
+                remove_temp_file
+                exit 1
+            fi
+
+            numUniqRep=`cat $TEST_DIR/.regression_test_out.txt | awk '{if($1 != 0) print $2}' | wc -l`
             if [ $numUniqRep -gt $n ]; then
                 echo "Error: Number of uniq windowRepInt is more than window samples. Impossible." >&2
                 echo "Cmd: $cmd" >&2
+                remove_temp_file
                 exit 1
             fi
             if [ $numUniqRep -eq 0 ] && [ $n -gt 0 ]; then
                 echo "Error: Did not find any windowRepInt. Impossible." >&2
                 echo "Cmd: $cmd" >&2
+                remove_temp_file
                 exit 1
             fi
         done
     done
 done
+remove_temp_file
 echo "Done Testing windowRepWindow Freq Mode"
 exit 0
 


### PR DESCRIPTION
windowRep regression test should now handle the rare cases where NBE and MCMC cannot sample out windows due to MAX_TRIES 
For the blant windowRep index mode, the output nodes are now changed to the actual network nodes. Made it easy for seeds alignment.