### PR TITLE
deterministic windowRep: add deg/num constr & comments

### DIFF
--- a/src/blant-window.h
+++ b/src/blant-window.h
@@ -44,7 +44,7 @@ extern Boolean _windowRep_limit_neglect_trivial;
 void FindWindowRepInWindow(GRAPH *G, SET *W, int *windowRepInt, int *D, char perm[]);
 void ProcessWindowRep(GRAPH *G, int *VArray, int windowRepInt);
 int ProcessWindowDistribution(GRAPH *G, SET *V, unsigned Varray[], int k, TINY_GRAPH *prev_graph, SET *prev_node_set, SET *intersect_node);
-int ExpandSeedsT1(GRAPH* G);
+int ExpandSeedsT1(GRAPH* G, int numSamples);
 
 
 #endif

--- a/src/blant.c
+++ b/src/blant.c
@@ -1056,8 +1056,7 @@ int main(int argc, char *argv[])
         _numWindowRepArrSize = 50;
         _windowReps = Calloc(_numWindowRepArrSize, sizeof(int*));
         for(i=0; i<_numWindowRepArrSize; i++) _windowReps[i] = Calloc(_k+1, sizeof(int));
-        _numWindowRepLimit = numSamples;
-        exitStatus = ExpandSeedsT1(G);
+        exitStatus = ExpandSeedsT1(G, numSamples);
     } else
 	exitStatus = RunBlantInThreads(_k, numSamples, G);
 #endif


### PR DESCRIPTION
1. Added function comments for future reference

2. updated degree and return number constraints of deterministic windowRep:

Sample call:
	./blant -k7 -w1 -lDEG5 -n3 networks/SCerevisiae.el

Usage:
	-lDEGL:  L specifies adding neighbor nodes with top L degrees for each extension step.
		   (When -lDEGL flag is not given, the function will loop through every neighbor nodes in descending order based 
                   on their degree during each extension step)
 	-n N:     N specifies the maximum number of WindowRep returned for each starting node
		   (When -n N flag is not given, then every satisfied windowRep will be returned.)