### PR TITLE
Added -mi and -mj output modes support to -w1 option

### DIFF
--- a/src/blant-output.c
+++ b/src/blant-output.c
@@ -179,6 +179,10 @@ void ProcessGraphlet(GRAPH *G, SET *V, unsigned Varray[], const int k, char perm
     if(UNIQ_GRAPHLETS && GraphletSeenRecently(G, Varray,k)) return;
     TinyGraphInducedFromGraph(g, G, Varray);
     int Gint = TinyGraph2Int(g,k), j, GintOrdinal=_K[Gint];
+    if (_window && _windowSize == 1 && !SetIn(_windowRep_unambig_set, GintOrdinal)) { // the graphlet is "ambiguous", so we don't print it and return directly
+        return;
+    }
+    if (_window)
 #if PARANOID_ASSERTS
     assert(0 <= GintOrdinal && GintOrdinal < _numCanon);
 #endif

--- a/src/blant-window.c
+++ b/src/blant-window.c
@@ -428,16 +428,22 @@ void buildTGraphlet(GRAPH* G, SET* prev_nodes, int numSamples, int *count) {
             _numWindowRepArrSize *= 2;
             _windowReps = Realloc(_windowReps, _numWindowRepArrSize * sizeof(int*));
             for(i=*count; i<_numWindowRepArrSize; i++) _windowReps[i] = Calloc(_k+1, sizeof(int));
-        }   
-        TinyGraphInducedFromGraph(g, G, prev_nodes_array);
-        Gint = TinyGraph2Int(g, _k);
-        TinyGraphFree(g);
+        }
+
+//        TINY_GRAPH *gTest = TinyGraphAlloc(_k);
+//        TinyGraphInducedFromGraph(gTest, G, prev_nodes_array);
+//        Gint = TinyGraph2Int(gTest, _k);
+//        TinyGraphFree(gTest);
         // only return unambiguous windowReps. Can add more constraints in the future
-        if(SetIn(_windowRep_unambig_set, _K[Gint])) {
-            for(i=0; i<_k; i++) _windowReps[*count][i] = prev_nodes_array[i];
-            _windowReps[*count][_k] = _K[Gint];
-            *count = *count + 1;
-        } 
+//        if(SetIn(_windowRep_unambig_set, _K[Gint])) {
+//            for(i=0; i<_k; i++) _windowReps[*count][i] = prev_nodes_array[i];
+//            _windowReps[*count][_k] = _K[Gint];
+//            assert(canonValTest == _K[Gint]);
+//        }
+
+        char perm[maxK+1];
+        ProcessGraphlet(G, NULL, prev_nodes_array, _k, perm, g);
+        *count = *count + 1;
         return;
     } 
 
@@ -483,7 +489,7 @@ void processExpandSeeds(int startNode, int count) {
     for(i=0; i<count; i++) {
         for(j=0; j<_k; j++) 
             PrintNode(_windowReps[i][j],' ');
-    //    printf("%i", _windowReps[i][_k]); Uncomment this line to print oridinal canonical ID at the end of the line. 
+       printf("%i", _windowReps[i][_k]); // Uncomment this line to print oridinal canonical ID at the end of the line. 
         printf("\n");
     }
 }
@@ -493,10 +499,11 @@ int ExpandSeedsT1(GRAPH* G, int numSamples) {
     SET *prev_nodes = SetAlloc(G->n);
     for(i=0; i<G->n; i++) {
         SetAdd(prev_nodes, i);
+        PrintNode(i, '\n');
         buildTGraphlet(G, prev_nodes, numSamples, &count);
         assert(SetCardinality(prev_nodes) == 1);
         SetDelete(prev_nodes, i);
-        processExpandSeeds(i, count);
+//        processExpandSeeds(i, count);
         count = 0;
     }
     SetFree(prev_nodes);

--- a/src/blant-window.c
+++ b/src/blant-window.c
@@ -422,27 +422,10 @@ void buildTGraphlet(GRAPH* G, SET* prev_nodes, int numSamples, int *count) {
 
     // Set a maximum number N of returned windowReps (-n N) in case there is a bunch 
     // If (-n N) flag is not given, then will return all satisfied windowReps.
-    if (numSamples != 0 && *count >= numSamples) return;  
-    if (prev_nodes_count == _k) {
-        if (*count == _numWindowRepArrSize) {
-            _numWindowRepArrSize *= 2;
-            _windowReps = Realloc(_windowReps, _numWindowRepArrSize * sizeof(int*));
-            for(i=*count; i<_numWindowRepArrSize; i++) _windowReps[i] = Calloc(_k+1, sizeof(int));
-        }
-
-//        TINY_GRAPH *gTest = TinyGraphAlloc(_k);
-//        TinyGraphInducedFromGraph(gTest, G, prev_nodes_array);
-//        Gint = TinyGraph2Int(gTest, _k);
-//        TinyGraphFree(gTest);
-        // only return unambiguous windowReps. Can add more constraints in the future
-//        if(SetIn(_windowRep_unambig_set, _K[Gint])) {
-//            for(i=0; i<_k; i++) _windowReps[*count][i] = prev_nodes_array[i];
-//            _windowReps[*count][_k] = _K[Gint];
-//            assert(canonValTest == _K[Gint]);
-//        }
-
+    if (numSamples != 0 && *count >= numSamples) return;  // already enough samples found, no need to search further
+    if (prev_nodes_count == _k) { // base case for the recursion: a k-graphlet is found, print it and return
         char perm[maxK+1];
-        ProcessGraphlet(G, NULL, prev_nodes_array, _k, perm, g);
+        ProcessGraphlet(G, NULL, prev_nodes_array, _k, perm, g); //
         *count = *count + 1;
         return;
     } 
@@ -483,27 +466,15 @@ void buildTGraphlet(GRAPH* G, SET* prev_nodes, int numSamples, int *count) {
     }
 }
 
-void processExpandSeeds(int startNode, int count) {
-    int i, j;
-    PrintNode(startNode,'\n');
-    for(i=0; i<count; i++) {
-        for(j=0; j<_k; j++) 
-            PrintNode(_windowReps[i][j],' ');
-       printf("%i", _windowReps[i][_k]); // Uncomment this line to print oridinal canonical ID at the end of the line. 
-        printf("\n");
-    }
-}
-
 int ExpandSeedsT1(GRAPH* G, int numSamples) {
     int i, count = 0;
     SET *prev_nodes = SetAlloc(G->n);
     for(i=0; i<G->n; i++) {
         SetAdd(prev_nodes, i);
-        PrintNode(i, '\n');
+        PrintNode(i, '\n'); // print the start node for the deterministic walk
         buildTGraphlet(G, prev_nodes, numSamples, &count);
         assert(SetCardinality(prev_nodes) == 1);
         SetDelete(prev_nodes, i);
-//        processExpandSeeds(i, count);
         count = 0;
     }
     SetFree(prev_nodes);

--- a/src/blant-window.c
+++ b/src/blant-window.c
@@ -425,7 +425,7 @@ void buildTGraphlet(GRAPH* G, SET* prev_nodes, int numSamples, int *count) {
     if (numSamples != 0 && *count >= numSamples) return;  // already enough samples found, no need to search further
     if (prev_nodes_count == _k) { // base case for the recursion: a k-graphlet is found, print it and return
         char perm[maxK+1];
-        ProcessGraphlet(G, NULL, prev_nodes_array, _k, perm, g); //
+        ProcessGraphlet(G, NULL, prev_nodes_array, _k, perm, g);
         *count = *count + 1;
         return;
     } 
@@ -471,7 +471,6 @@ int ExpandSeedsT1(GRAPH* G, int numSamples) {
     SET *prev_nodes = SetAlloc(G->n);
     for(i=0; i<G->n; i++) {
         SetAdd(prev_nodes, i);
-        PrintNode(i, '\n'); // print the start node for the deterministic walk
         buildTGraphlet(G, prev_nodes, numSamples, &count);
         assert(SetCardinality(prev_nodes) == 1);
         SetDelete(prev_nodes, i);

--- a/src/blant.c
+++ b/src/blant.c
@@ -1085,14 +1085,10 @@ int main(int argc, char *argv[])
         exitStatus = GenSynGraph(_k, _k_small, numSamples, G, fpSynGraph);
     }
 #endif
-    if(_windowSize == 1) {
+    if(_windowSize == 1) { // -w1 mode used for deterministic walk
         if (_outputMode != indexGraphlets && _outputMode != indexOrbits) {
             Fatal("currently only -mi and -mj output modes are supported for -w1 option");
-//            _outputMode = indexGraphlets;
         }
-        _numWindowRepArrSize = 50;
-        _windowReps = Calloc(_numWindowRepArrSize, sizeof(int*));
-        for(i=0; i<_numWindowRepArrSize; i++) _windowReps[i] = Calloc(_k+1, sizeof(int));
         exitStatus = ExpandSeedsT1(G, numSamples);
     } else
 	exitStatus = RunBlantInThreads(_k, numSamples, G);

--- a/src/blant.c
+++ b/src/blant.c
@@ -952,7 +952,7 @@ int main(int argc, char *argv[])
 	}
     }
 
-    if (_windowSize == 1 && _k <= 5) Fatal("k is %d but must be between larger than 5 for window size of 1 since there are no unambiguous graphlets for k<=5",_k); 
+    if (_windowSize == 1 && _k <= 5) Fatal("k is %d but must be between larger than 5 for window size of 1 since there are no unambiguous graphlets for k<=5",_k);
 
     if(_seed == -1) _seed = GetFancySeed(false);
     // This only seeds the main thread; sub-threads, if they exist, are seeded later by "stealing"
@@ -1086,6 +1086,10 @@ int main(int argc, char *argv[])
     }
 #endif
     if(_windowSize == 1) {
+        if (_outputMode != indexGraphlets && _outputMode != indexOrbits) {
+            Fatal("currently only -mi and -mj output modes are supported for -w1 option");
+//            _outputMode = indexGraphlets;
+        }
         _numWindowRepArrSize = 50;
         _windowReps = Calloc(_numWindowRepArrSize, sizeof(int*));
         for(i=0; i<_numWindowRepArrSize; i++) _windowReps[i] = Calloc(_k+1, sizeof(int));


### PR DESCRIPTION
1. added -mi and -mj support for -w1 option, to make the output for deterministic walk mode consistent with the output for other modes.
2. added constraint for -w1 output, because it only supports -mi and -mj so far