### PR TITLE
BLANT can compile successfully with blant-predict-stub.c/without EdgePredict submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ BLANT_SRCS = blant.c \
 OBJDIR = _objs
 OBJS = $(addprefix $(OBJDIR)/, $(BLANT_SRCS:.c=.o))
 
+ifneq ("$(wildcard $(blant-predict.c))","")
+    BLANT_PREDICT_SRC = $(SRCDIR)/EdgePredict/blant-predict.c
+else
+    BLANT_PREDICT_SRC = $(SRCDIR)/blant-predict-stub.c
+$(info BLANT EdgePredict not found, and edge prediction will not be supported. Utilizing stub at $(BLANT_PREDICT_SRC) instead.)
+endif
+
+
 ### Generated File Lists ###
 
 # these variables serve only to help in the creation of the generated file lists variables
@@ -196,7 +204,7 @@ make-orca-jesse-blant-table: libwayne $(SRCDIR)/blant-fundamentals.h $(SRCDIR)/m
 cluster-similarity-graph: libwayne src/cluster-similarity-graph.c
 	$(CC) $(LIBWAYNE_COMP) $(SPEED) -Wall -o $@ $(SRCDIR)/cluster-similarity-graph.c
 
-$(OBJDIR)/blant-predict.o: $(SRCDIR)/EdgePredict/blant-predict.c | $(SRCDIR)/blant-predict-stub.c
+$(OBJDIR)/blant-predict.o: $(BLANT_PREDICT_SRC)
 	if [ -f $(SRCDIR)/EdgePredict/Makefile ]; then (CC="$(CC) $(PRED_REG_OPT) $(LIBWAYNE_COMP)"; export CC; OBJDIR="$(OBJDIR)"; export OBJDIR; cd $(SRCDIR)/EdgePredict && $(MAKE)); else $(CC) $(PRED_REG_OPT) -c -o $@ $(SRCDIR)/blant-predict-stub.c $(LIBWAYNE_BOTH); fi
 
 ### Object Files/Prereqs ###

--- a/src/blant-predict-stub.c
+++ b/src/blant-predict-stub.c
@@ -13,3 +13,5 @@ void Predict_ProcessGraphlet(GRAPH *G, unsigned Varray[], TINY_GRAPH *g, Gint_ty
     {Fatal("prediction not supported");};
 Gint_type Predict_canon_map(Gint_type num, int k, unsigned char* return_permutation)
     {Fatal("prediction not supported"); return -1;}
+void Predict_Shutdown(GRAPH *G) 
+    {Fatal("prediction not supported");}


### PR DESCRIPTION
I deleted the old branch and PR so that the whitespace fix was apparent. 
A note for future students who may ever read this: if on Windows, if you commit with Git on WSL, the end of line will match the repository's, but if you commit with Git without being on WSL, it'll change the end of line and cause whitespace issues.

(From old PR:)
BLANT can now successfully compile when EdgePredict submodule is not available. It's tested on my machine, where EdgePredict isn't available, but further testing to FULLY ensure everything works should occur on OpenLab machines where EdgePredict is available. Though I don't expect anything to go wrong.

Added code for Predict_Shutdown to blant-predict-stub.c, which was missing but specified in blant-predict.h
Changed Makefile so the prerequisite for EdgePredict is a variable BLANT_PREDICT_SRC that depends on the existence of EdgePredict submodule