### PR TITLE
added re-sampling if a graphlet wasn't processed, refactored var _JOBS to more accurate _NUM_THREADS

### DIFF
--- a/src/blant.h
+++ b/src/blant.h
@@ -33,7 +33,7 @@ double RandomUniform(void) {
 #define GEN_SYN_GRAPH 0
 
 #define MAX_POSSIBLE_THREADS 64 // set this to something reasonable on your machine (eg odin.ics.uci.edu has 64 cores)
-extern int _JOBS, _MAX_THREADS;
+extern int _NUM_THREADS, _MAX_THREADS;
 extern unsigned long _numSamples;
 extern double _confidence; // for confidence intervals
 extern Boolean _earlyAbort;  // Can be set true by anybody anywhere, and they're responsible for producing a warning as to why


### PR DESCRIPTION
Now currently dealing with the NodeSetSeenRecently non-reentrant problem, but here's the latest version of the code in case you want to play around with it, and so I won't have to rebase if you make changes. See Skype for more info about NodeSetSeenRecently.

In main(), for simplicity, RunBlantInForks is no longer called, and RunBlantInGraph is called instead, which is where multiple RunBlantInThread processes are created. Previously, RunBlantInGraph was called inside RunBlantInForks. I just cut out the middleman of RunBlantInGraph.

Since the end goal is to replace RunBlantInForks, and this is a WIP branch, this is no issue.