### PR TITLE
made RNG for rand48 and MT options thread safe

### DIFF
--- a/src/blant-output.c
+++ b/src/blant-output.c
@@ -105,7 +105,9 @@ static GRAPH *_G; // local copy of GRAPH *G
 
 // NOTE WE DO NOT CHECK EDGES. So if you call it with the same node set but as a motif, it'll (incorrectly) return TRUE
 // Also this is NON-RE-ENTRANT.
+// Only does anything if sampling method is MCMC, otherwise returns false. This is because this function is terribly non re-entrant
 Boolean NodeSetSeenRecently(GRAPH *G, unsigned Varray[], int k) {
+    if (_sampleMethod != SAMPLE_MCMC && _sampleMethod != SAMPLE_MCMC_EC) return false;
     if(_G) assert(_G == G); // only allowed to set it once
     else _G=G;
     //if(_JOBS>1 || _MAX_THREADS>1) Apology("NodeSetSeenRecently is not re-entrant (called with %d jobs and %d max threads)", _JOBS, _MAX_THREADS);

--- a/src/blant.h
+++ b/src/blant.h
@@ -11,23 +11,8 @@
 #include "Oalloc.h"
 // #include "mem-debug.h" // need this if you use ENABLE_MEMORY_TRACKING() at the top of main().
 
-#define USE_MarsenneTwister 0
-#if USE_MarsenneTwister
-#include "libwayne/MT19937/mt19937.h"
-static MT19937 *_mt19937;
-#define RandomSeed SeedMt19937
-void SeedMt19937(int seed) {
-    if(_mt19937) Mt19937Free(_mt19937);
-    _mt19937 = Mt19937Alloc(seed);
-}
-double RandomUniform(void) {
-    return Mt19937NextDouble(_mt19937);
-}
-#else
-#include "rand48.h"
-#define RandomUniform drand48
-#define RandomSeed srand48
-#endif
+void RandomSeed(long seed);
+double RandomUniform(void);
 
 #define USE_INSERTION_SORT 0
 #define GEN_SYN_GRAPH 0
@@ -196,6 +181,7 @@ typedef struct {
     GRAPH *G;
     int varraySize;
     Accumulators accums;
+    long seed;
 } ThreadData;
 void* RunBlantInThread(void* arg);
 

--- a/src/blant.h
+++ b/src/blant.h
@@ -33,7 +33,7 @@ double RandomUniform(void) {
 #define GEN_SYN_GRAPH 0
 
 #define MAX_POSSIBLE_THREADS 64 // set this to something reasonable on your machine (eg odin.ics.uci.edu has 64 cores)
-extern int _JOBS, _MAX_THREADS;
+extern int _NUM_THREADS, _MAX_THREADS;
 extern unsigned long _numSamples;
 extern double _confidence; // for confidence intervals
 extern Boolean _earlyAbort;  // Can be set true by anybody anywhere, and they're responsible for producing a warning as to why


### PR DESCRIPTION
Random number generation is non-reentrant and has no static/global variable state.
1) Moved RNG function definition (RandomSeed, RandomUniform) from blant.h to blant.c, leaving their function declaration in blant.h
2) Made RanomSeed and RandomUniform normal functions rather than compiler macros (I assume this is alright)

Now, if you specify seed when running multithreading, ASSUMING you specify the same number of threads, you'll always get the same result. The program has a `base_seed`, and each thread is seeded as `base_seed` plus the thread number, essentially producing orthogonal sequence of random numbers, which is what we wanted.

Aside from that, some minor things, such as refactoring some variable names, no longer ever calling RunBlantInForks and instead using RunBlantInGraph, and re-sampling when encountering a graphlet that was not processed.