### PR TITLE
implemented EBE sampling method and ODV and GDV output methods for multithreading

### DIFF
--- a/src/blant-output.c
+++ b/src/blant-output.c
@@ -105,7 +105,9 @@ static GRAPH *_G; // local copy of GRAPH *G
 
 // NOTE WE DO NOT CHECK EDGES. So if you call it with the same node set but as a motif, it'll (incorrectly) return TRUE
 // Also this is NON-RE-ENTRANT.
+// Only does anything if sampling method is MCMC, otherwise returns false. This is because this function is terribly non re-entrant
 Boolean NodeSetSeenRecently(GRAPH *G, unsigned Varray[], int k) {
+    if (_sampleMethod != SAMPLE_MCMC && _sampleMethod != SAMPLE_MCMC_EC) return false;
     if(_G) assert(_G == G); // only allowed to set it once
     else _G=G;
     //if(_JOBS>1 || _MAX_THREADS>1) Apology("NodeSetSeenRecently is not re-entrant (called with %d jobs and %d max threads)", _JOBS, _MAX_THREADS);

--- a/src/blant-sampling.c
+++ b/src/blant-sampling.c
@@ -285,12 +285,12 @@ double SampleGraphletNodeBasedExpansion(GRAPH *G, SET *V, unsigned *Varray, int 
 	double ocount = (double)multiplier/((double)_alphaList[GintOrdinal]);
 	if (_outputMode & outputODV) {
 	    for (j = 0; j < k; j++) {
-		_doubleOrbitDegreeVector[_orbitList[GintOrdinal][j]][Varray[(int)perm[j]]] += ocount;
+		accums->doubleOrbitDegreeVector[_orbitList[GintOrdinal][j]][Varray[(int)perm[j]]] += ocount;
 	    }
 	}
 	if (_outputMode & outputGDV) {
 	    for (j = 0; j < k; j++) {
-		_doubleGraphletDegreeVector[GintOrdinal][Varray[(int)perm[j]]] += ocount;
+        accums->doubleGraphletDegreeVector[GintOrdinal][Varray[(int)perm[j]]] += ocount;
 	    }
 	}
 	if(ocount < 0) {
@@ -634,12 +634,14 @@ double SampleGraphletEdgeBasedExpansion(GRAPH *G, SET *V, unsigned *Varray, int 
 	Gordinal_type GintOrdinal = ExtractPerm(perm, Gint);
 	double ocount = (double)multiplier/((double)_alphaList[GintOrdinal]);
 	if (_outputMode & outputODV) {
-	    for (j = 0; j < k; j++)
-		_doubleOrbitDegreeVector[_orbitList[GintOrdinal][j]][Varray[(int)perm[j]]] += ocount;
+	    for (j = 0; j < k; j++) {
+		accums->doubleOrbitDegreeVector[_orbitList[GintOrdinal][j]][Varray[(int)perm[j]]] += ocount;
+	    }
 	}
 	if (_outputMode & outputGDV) {
-	    for (j = 0; j < k; j++)
-		_doubleGraphletDegreeVector[GintOrdinal][Varray[(int)perm[j]]] += ocount;
+	    for (j = 0; j < k; j++) {
+        accums->doubleGraphletDegreeVector[GintOrdinal][Varray[(int)perm[j]]] += ocount;
+	    }
 	}
 	if(ocount < 0) {
 	    Warning("ocount (%g) is less than 0\n", ocount);

--- a/src/blant-sampling.h
+++ b/src/blant-sampling.h
@@ -42,7 +42,7 @@ extern GRAPH *_EDGE_COVER_G;
 double SampleGraphletNodeBasedExpansion(GRAPH *G, SET *V, unsigned *Varray, int k, int whichCC, Accumulators *accums);
 double SampleGraphletFaye(GRAPH *G, SET *V, unsigned *Varray, int k, int whichCC);
 double SampleGraphletFromFile(GRAPH *G, SET *V, unsigned *Varray, int k);
-double SampleGraphletEdgeBasedExpansion(GRAPH *G, SET *V, unsigned *Varray, int k, int whichCC);
+double SampleGraphletEdgeBasedExpansion(GRAPH *G, SET *V, unsigned *Varray, int k, int whichCC, Accumulators *accums);
 double SampleGraphletLuBressanReservoir(GRAPH *G, SET *V, unsigned *Varray, int k, int whichCC);
 double SampleGraphletAcceptReject(GRAPH *G, SET *V, unsigned *Varray, int k);
 double SampleGraphletMCMC(GRAPH *G, SET *V, unsigned *Varray, int k, int whichCC);

--- a/src/blant.h
+++ b/src/blant.h
@@ -11,23 +11,8 @@
 #include "Oalloc.h"
 // #include "mem-debug.h" // need this if you use ENABLE_MEMORY_TRACKING() at the top of main().
 
-#define USE_MarsenneTwister 0
-#if USE_MarsenneTwister
-#include "libwayne/MT19937/mt19937.h"
-static MT19937 *_mt19937;
-#define RandomSeed SeedMt19937
-void SeedMt19937(int seed) {
-    if(_mt19937) Mt19937Free(_mt19937);
-    _mt19937 = Mt19937Alloc(seed);
-}
-double RandomUniform(void) {
-    return Mt19937NextDouble(_mt19937);
-}
-#else
-#include "rand48.h"
-#define RandomUniform drand48
-#define RandomSeed srand48
-#endif
+void RandomSeed(long seed);
+double RandomUniform(void);
 
 #define USE_INSERTION_SORT 0
 #define GEN_SYN_GRAPH 0
@@ -196,6 +181,7 @@ typedef struct {
     GRAPH *G;
     int varraySize;
     Accumulators accums;
+    long seed;
 } ThreadData;
 void* RunBlantInThread(void* arg);
 

--- a/src/blant.h
+++ b/src/blant.h
@@ -172,6 +172,8 @@ typedef struct {
     // local accumulator values, they function the same as globals but ARE LOCAL TO THREADS
     double graphletCount[MAX_CANONICALS];
     double graphletConcentration[MAX_CANONICALS];
+    double *doubleGraphletDegreeVector[MAX_CANONICALS];
+    double *doubleOrbitDegreeVector[MAX_ORBITS];
 } Accumulators;
 
 // https://docs.oracle.com/cd/E19120-01/open.solaris/816-5137/tlib-4/index.html

--- a/src/blant.h
+++ b/src/blant.h
@@ -33,7 +33,7 @@ double RandomUniform(void) {
 #define GEN_SYN_GRAPH 0
 
 #define MAX_POSSIBLE_THREADS 64 // set this to something reasonable on your machine (eg odin.ics.uci.edu has 64 cores)
-extern int _JOBS, _MAX_THREADS;
+extern int _NUM_THREADS, _MAX_THREADS;
 extern unsigned long _numSamples;
 extern double _confidence; // for confidence intervals
 extern Boolean _earlyAbort;  // Can be set true by anybody anywhere, and they're responsible for producing a warning as to why


### PR DESCRIPTION
Only the last 2 commits for this PR, not sure what the business is with all the other ones.

A couple things to note:
1) There's a slight drop off when specifying too many threads. For example, for EBE sampling with threads up to 4 for 1000000 samples, you get the expected speed up. Going to 8 threads gives you a much smaller than expected speed up, and going to 16 threads actually takes longer than 8 threads. There is definitely overhead for each thread, and if you have too small a sample size and too many threads, multithreading definitely slow things down a bit. The effect is exemplified when using EBE, probably because it's much faster than NBE.

2) If you try to run EBE sampling for a huge number of samples, it suddenly kills itself. Not sure why. But when using NBE, this doesn't happen. Maybe you know why? I have no idea. It just says "Killed" definitely not printed by the code, just from the system. Resource problem? See below:
```
echennau@LAPTOP-8V8EHD0M:/mnt/c/Users/ethan/school/BLANT$ ./blant -r 5 -s EBE -t 16 -mf -n 1000000000 -k 3 networks/syeast.el
Note: Sampling method is EBE
Note: Running BLANT in 16 threads, with about 62500000 samples per thread, for a total of 1000000000 samples.
Killed
echennau@LAPTOP-8V8EHD0M:/mnt/c/Users/ethan/school/BLANT$ ./blant -r 5 -s NBE -t 16 -mf -n 1000000000 -k 3 networks/syeast.el
Note: Sampling method is NBE
Note: Running BLANT in 16 threads, with about 62500000 samples per thread, for a total of 1000000000 samples.
Note: Took 382.380675 seconds to sample 1000000000 with 16 threads.
116445 2
62497 3
```

Not sure what to work on next but I'll figure it out by the weekend and keep you updated. Probably another output mode.