### PR TITLE
Fixed memory bugs (hopefully)

### DIFF
--- a/src/fast-canon-map.c
+++ b/src/fast-canon-map.c
@@ -7,8 +7,8 @@
 #include "blant.h"
 #define totalCanons 1540944
 
-static int k;
-static long numBitValues;
+static int k; 
+static long numBitValues; 
 static bool directed;
 
 
@@ -17,7 +17,7 @@ static bool directed;
 unsigned long bitArrayToDecimal(int bitMatrix[k][k], char Permutations[], int numBits){
     unsigned long num=0;
     int lf=0;
-    for(int i = 1; i < k; i++)
+    for(int i = 0; i < k; i++)
 	for(int j=0; j <( directed ? k:i); j++){
 	    if(i==j) continue;
 	    num+=(((unsigned long)bitMatrix[(int)Permutations[i]][(int)Permutations[j]]) << (numBits-1-lf));
@@ -27,9 +27,9 @@ unsigned long bitArrayToDecimal(int bitMatrix[k][k], char Permutations[], int nu
 }
 
 void decimalToBitArray(int bitMatrix[k][k], unsigned long D){
-    for(int i=k-1; i>0; i--)
+    for(int i=k-1; i>=0; i--)
 	for(int j=(directed ? k-1 : i-1); j>=0; j--){
-	    if(i==j) continue;
+	    if(i==j) continue;	
 	    bitMatrix[i][j] = D%2;
 	    if(!directed) bitMatrix[j][i]=bitMatrix[i][j];
 	    D = D/2;
@@ -45,7 +45,7 @@ unsigned long bitArrayToDecimal(int bitMatrix[k][k], char Permutations[], int nu
     for(int i = 0; i < k; i++)
     for(int j = (i+1)*(1-directed); j < k; j++){
 	if(i==j) continue;
-	num+=(((unsigned long)bitMatrix[(int)Permutations[i]][(int)Permutations[j]]) << (numBits-1-lf));
+	num+=(((unsigned long)bitMatrix[(int)Permutations[i]][(int)Permutations[j]]) << (numBits-1-lf)); 
 	lf++;
     }
     return num;
@@ -107,9 +107,9 @@ long factorial(int n) {
 
 bool nextPermutation(int permutation[]) {
     for(int i=k-1;i>0;i--) {
-	if(permutation[i]>permutation[i-1]) {
+	if(permutation[i]>permutation[i-1]) { 
 	    for(int j=k-1;j>i-1;j--){
-		if(permutation[i-1]<permutation[j]){
+		if(permutation[i-1]<permutation[j]){ 
 		    int t=permutation[i-1];
 		    permutation[i-1]=permutation[j];
 		    permutation[j]=t;
@@ -128,7 +128,7 @@ bool nextPermutation(int permutation[]) {
 	return 1;
 	}
     }
-    return 0;
+    return 0; 
 }
 
 void canon_map(void){

--- a/src/fast-canon-map.c
+++ b/src/fast-canon-map.c
@@ -7,8 +7,8 @@
 #include "blant.h"
 #define totalCanons 1540944
 
-static int k;
-static long numBitValues;
+static int k; 
+static long numBitValues; 
 static bool directed;
 
 
@@ -17,7 +17,7 @@ static bool directed;
 unsigned long bitArrayToDecimal(int bitMatrix[k][k], char Permutations[], int numBits){
     unsigned long num=0;
     int lf=0;
-    for(int i = 1; i < k; i++)
+    for(int i = 0; i < k; i++)
 	for(int j=0; j <( directed ? k:i); j++){
 	    if(i==j) continue;
 	    num+=(((unsigned long)bitMatrix[(int)Permutations[i]][(int)Permutations[j]]) << (numBits-1-lf));
@@ -27,9 +27,9 @@ unsigned long bitArrayToDecimal(int bitMatrix[k][k], char Permutations[], int nu
 }
 
 void decimalToBitArray(int bitMatrix[k][k], unsigned long D){
-    for(int i=k-1; i>0; i--)
+    for(int i=k-1; i>=0; i--)
 	for(int j=(directed ? k-1 : i-1); j>=0; j--){
-	    if(i==j) continue;
+	    if(i==j) continue;	
 	    bitMatrix[i][j] = D%2;
 	    if(!directed) bitMatrix[j][i]=bitMatrix[i][j];
 	    D = D/2;
@@ -45,7 +45,7 @@ unsigned long bitArrayToDecimal(int bitMatrix[k][k], char Permutations[], int nu
     for(int i = 0; i < k; i++)
     for(int j = (i+1)*(1-directed); j < k; j++){
 	if(i==j) continue;
-	num+=(((unsigned long)bitMatrix[(int)Permutations[i]][(int)Permutations[j]]) << (numBits-1-lf));
+	num+=(((unsigned long)bitMatrix[(int)Permutations[i]][(int)Permutations[j]]) << (numBits-1-lf)); 
 	lf++;
     }
     return num;
@@ -75,8 +75,8 @@ unsigned long power(int x, int y){
     return (unsigned long)x*power(x,y-1);
 }
 
-void encodeChar(xChar ch, long indexD, long indexP){
-    unsigned long x=(unsigned long)indexD+(unsigned long)indexP*(1<<(directed ?30 : 14));
+void encodeChar(xChar ch, long indexD, long indexP){ 
+    unsigned long x=(unsigned long)indexD+(unsigned long)indexP*(1<<(directed ? 30 : 14));
     for(int i=4; i>=0; i--){
 	ch[i]=(char)(x%(1<<8));
 	x>>=8;
@@ -94,7 +94,7 @@ void decodeChar(xChar ch, long* indexD, long* indexP){
 	x+=w*m;
 	y+=8;
     }
-    unsigned long z=(1<<(directed ? 30: 14));
+    unsigned long z=(1<<(directed ? 30 : 14));
     *indexD=x%z;
     *indexP=x/z;
 }
@@ -107,9 +107,9 @@ long factorial(int n) {
 
 bool nextPermutation(int permutation[]) {
     for(int i=k-1;i>0;i--) {
-	if(permutation[i]>permutation[i-1]) {
+	if(permutation[i]>permutation[i-1]) { 
 	    for(int j=k-1;j>i-1;j--){
-		if(permutation[i-1]<permutation[j]){
+		if(permutation[i-1]<permutation[j]){ 
 		    int t=permutation[i-1];
 		    permutation[i-1]=permutation[j];
 		    permutation[j]=t;
@@ -128,7 +128,7 @@ bool nextPermutation(int permutation[]) {
 	return 1;
 	}
     }
-    return 0;
+    return 0; 
 }
 
 void canon_map(void){
@@ -234,8 +234,8 @@ int main(int argc, char* argv[]){
     k = atoi(argv[1]); assert(2<=k && k<=8);
     numBitValues = (1UL << (k*(k-1)/(2-directed)));
     assert(numBitValues>0);
-    data = malloc(sizeof(xChar)*numBitValues);
-    done = malloc(sizeof(bool)*numBitValues);
+    data = calloc(sizeof(xChar),numBitValues);
+    done = calloc(sizeof(bool),numBitValues);
     canon_map();
 
     return 0;


### PR DESCRIPTION
Reverted some changes in my last PR that (most likely) caused the memory bugs

fast-canon-map runs fine now with the directed option