### PR TITLE
Fixed issue with stop mode defaulting

### DIFF
--- a/src/blant.c
+++ b/src/blant.c
@@ -1701,6 +1701,7 @@ int main(int argc, char *argv[])
     if(!numSamples && !_desiredPrec) { // default to 2 digits of precision at 99.9% confidence
 	_desiredDigits = DEFAULT_DIGITS;
 	_desiredPrec = pow(10, -_desiredDigits);
+    _stopMode = stopOnPrecision; // set default stop mode
     }
     if (_sampleMethod == -1) {
 	_sampleMethod = SAMPLE_EDGE_EXPANSION;


### PR DESCRIPTION
Issue description:
"when neither -n{numSamples} nor -p{precision} are specified, there's code that should make it default to precision with DEFAULT_PRECISION... and that works... but in that case, numSamples is zero, and it causes an assertion failure at output time."

Fixed. The below commands are functionally equivalent:
- `./blant -k3 -s NBE networks/syeast.el`
- `./blant -k3 -p 2 -s NBE networks/syeast.el`

