### PR TITLE
alternate dynamic canon map method

### DIFF
--- a/src/blant-fundamentals.h
+++ b/src/blant-fundamentals.h
@@ -76,6 +76,8 @@
 // If 1, then the graphlet with the lowest decimal value among all permutations that also has the property that 
 // among the neighbors of a node (say x), each neighbor has degree greater than or equal to the previous node, when considering the induced subgraph of nodes x+1...n.
 #define CANON_ASCENDING_NEIGHBORS 0
+#define SORT_CUBED_SUM 0
+//When canon_ascending_neighbors is on - instead of sorting by degree, we sort by the sum of the cubes of the degrees of the neighbors of nodes
 
 // Once we find which canonical graphlet corresponds to a sampled graphlet, we want to know the permutation between the
 // two.  We default to the permutation from the canonical to the sampled non-canonical; thus, when we list the nodes

--- a/src/blant-utils.c
+++ b/src/blant-utils.c
@@ -142,14 +142,27 @@ static Gint_type L_K_Func_Sort(Gint_type Gint) {
     g.n = _k;
     TinyGraphEdgesAllDelete(&g);
     Int2TinyGraph(&g, Gint);
-    TinyGraphSortByDegree(&g);
-
+    #if SORT_CUBED_SUM
+    TinyGraphSort(&g, true);
+    #else
+    TinyGraphSort(&g, false);
+    #endif
     int groupStart[_k + 1], numGroups = 0, i;
     groupStart[0] = 0;
-    for(i = 1; i <= _k; i++)
+    for(i = 1; i <= _k; i++){
+        #if SORT_CUBED_SUM
+        int sum = 0, sumPrev = 0;
+        for(int k = 0; k < _k; k++) {
+            if(TinyGraphAreConnected(&g, i, k)) sum += g.degree[k] * g.degree[k] * g.degree[k];
+            if(TinyGraphAreConnected(&g, i-1, k)) sumPrev += g.degree[k] * g.degree[k] * g.degree[k];
+        }
+        if(i == _k || sum < sumPrev)
+            groupStart[++numGroups] = i;
+        #else
         if(i == _k || g.degree[i] != g.degree[i-1])
             groupStart[++numGroups] = i;
-
+        #endif
+        }
     _sortBest = ~(Gint_type)0;
     _tryGroupPerms(&g, groupStart, numGroups, 0, 0);
     return _sortBest;


### PR DESCRIPTION
Instead of sorting by degree of node, sort by the sum of the cubed degrees of the neighbors. Should be faster for larger k