### PR TITLE
Add customizable variant builds and incremental dynamic recompilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,384 +1,132 @@
-# Number of cores to use when invoking parallelism
-#ifndef CORES
-CORES := 2 # temporarily set to 1 since I broke threading. :-(
-#endif
-ifndef PAUSE   
-	PAUSE := 1
-endif
-# Uncomment either of these to remove them (removing 7 implies removing 8)
-MAX_K := 8
-EIGHT := 8
-SEVEN := 7
-ifdef NO8
-    MAX_K := 7
-    EIGHT := 
-endif
-ifdef NO7
-    MAX_K := 6
-    SEVEN :=
-    EIGHT := # can't have 8 without 7
-endif
-
-# to make the prediction version that agrees with the regression tests
-ifdef PRED_REG
-    PRED_REG_OPT := -DINTERNAL_DEG_WEIGHTS=0 -DDEG_ORDER_MUST_AGREE=1
-endif
-
-ifdef DEBUG
-    ifdef PROFILE
-	SPEED=-O0 -ggdb -pg
-	LIB_OPT=-pg-g
-    else
-	SPEED=-O0 -ggdb
-	LIB_OPT=-g
-    endif
-else
-    ifdef PROFILE
-	SPEED=-O3 -pg
-	LIB_OPT=-pg
-    else
-	SPEED=-O3 #-DNDEBUG
-	LIB_OPT= #-nd # NDEBUG
-    endif
-endif
-
-ifdef STATIC
-    STATIC_LINK=-static
-endif
-
-#GCC= $(shell $(CC) -v 2>&1 | awk '/gcc/{++gcc}{V=$$3}END{if(gcc && (V ~ /[0-9]\.[0-9]\.[0-9]*/))print "$(UNAME).gcc"V; else exit 1}')
-#GCC_VER=$(shell echo $(UNAME) $(HOME) | awk '/Darwin/&&/Users.wayne/{V="-6"}END{if(V)print V;else{printf "using default gcc: " > "/dev/null"; exit 1}}')
-GCC=gcc$(GCC_VER) $(SPEED) $(NDEBUG)
-CXX=g++$(GCC_VER) $(SPEED) $(NDEBUG)
-
-# Some systems, eg CYGWIN 32-bit and MacOS("Darwin") need an 80MB stack.
-export LIBWAYNE_HOME=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/libwayne
+# Attempt to figure out what kind of machine we're on.
 UNAME=$(shell uname -a | awk '{if(/CYGWIN/){V="CYGWIN"}else if(/Darwin/){if(/arm64/)V="arm64";else V="Darwin"}else if(/Linux/){V="Linux"}}END{if(V){print V;exit}else{print "unknown OS" > "/dev/stderr"; exit 1}}')
 
-STACKSIZE=$(shell ($(GCC) -v 2>/dev/null; uname -a) | awk '/CYGWIN/{print "-Wl,--stack,83886080"}/gcc-/{actualGCC=1}/Darwin/{print "-Wl,-stack_size -Wl,0x5000000"}')
-CC=$(GCC) $(SPEED) $(NDEBUG) -Wno-misleading-indentation -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-variable -Wall -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wshadow $(PG)
-LIBWAYNE_COMP=-I $(LIBWAYNE_HOME)/include $(SPEED)
-LIBWAYNE_LINK=-L $(LIBWAYNE_HOME) -lwayne$(LIB_OPT) -lm -lpthread $(STACKSIZE) $(SPEED) $(STATIC_LINK)
-LIBWAYNE_BOTH=$(LIBWAYNE_COMP) $(LIBWAYNE_LINK)
-
-# Name of BLANT source directory
-SRCDIR = src
-
-# All the headers (except synthetic ones which are orthogonal to blant itself)
-RAW_HEADERS = blant-fundamentals.h blant.h blant-output.h blant-predict.h blant-sampling.h blant-utils.h blant-window.h importance.h odv.h uthash.h blant-pthreads.h
-BLANT_HEADERS = $(addprefix $(SRCDIR)/, $(RAW_HEADERS))
-
-# Put all c files in SRCDIR below.
-BLANT_SRCS = blant.c \
-			 blant-window.c \
-			 blant-output.c \
-			 blant-utils.c \
-			 blant-sampling.c \
-			 blant-predict.o \
-			 blant-synth-graph.c \
-			 importance.c \
-			 odv.c \
-			 blant-pthreads.c
-
-OBJDIR = _objs
-BLANT_CANON_DIR = canon_maps
-UND_CANON_DIR := $(BLANT_CANON_DIR)
-DIR_CANON_DIR := $(BLANT_CANON_DIR)/directed
-
-# directed canonical values; start with the full range 3..6
-# and then remove entries when NO8 or NO7 are set.  This keeps the
-# format identical to the `K` list used for undirected data.
-K_DIR := 3 4 5 #6
-ifdef NO8
-	# don't build k=6 if undirected 8 is disabled
-	K_DIR := $(filter-out 6,$(K_DIR))
-endif
-ifdef NO7
-	# NO7 implies NO8; drop both 5 and 6
-	K_DIR := $(filter-out 5 6,$(K_DIR))
-endif
-ifdef NO_DIRECTED
-	# skip all directed canon generation
-	K_DIR :=
-endif
-OBJS = $(addprefix $(OBJDIR)/, $(BLANT_SRCS:.c=.o))
-
-ifneq ("$(wildcard $(SRCDIR)/EdgePredict/blant-predict.c)","")
-    BLANT_PREDICT_SRC = $(SRCDIR)/EdgePredict/blant-predict.c
-else
-    BLANT_PREDICT_SRC = $(SRCDIR)/blant-predict.c
+# Number of cores to use when invoking parallelism
+ifndef CORES
+    CORES := 2
 endif
 
-
-### Generated File Lists ###
-
-# these variables serve only to help in the creation of the generated file lists variables
-K := 3 4 5 6 $(SEVEN) $(EIGHT)
-alpha_sampling_methods := NBE EBE MCMC
-alpha_txts_ud := $(foreach method,$(alpha_sampling_methods),$(UND_CANON_DIR)/alpha_list_$(method))
-canon_txt_ud := $(UND_CANON_DIR)/canon_map $(UND_CANON_DIR)/canon_list $(UND_CANON_DIR)/canon-ordinal-to-signature $(UND_CANON_DIR)/orbit_map $(alpha_txts_ud)
-canon_txt_dir := $(DIR_CANON_DIR)/canon_map $(DIR_CANON_DIR)/canon_list $(DIR_CANON_DIR)/canon-ordinal-to-signature $(DIR_CANON_DIR)/orbit_map $(alpha_txts_dir)
-canon_bin_ud := $(UND_CANON_DIR)/canon_map $(UND_CANON_DIR)/perm_map
-canon_bin_dir := $(DIR_CANON_DIR)/canon_map $(DIR_CANON_DIR)/perm_map
-
-# actual generated file lists variables
-canon_all_ud := $(foreach k, $(K), $(addsuffix $(k).txt, $(canon_txt_ud)) $(addsuffix $(k).bin, $(canon_bin_ud)))
-canon_all_dir := $(foreach k, $(K_DIR), $(addsuffix $(k).txt, $(canon_txt_dir)) $(addsuffix $(k).bin, $(canon_bin_dir)))
-canon_all := $(canon_all_ud) $(canon_all_dir)
-subcanon_txts := $(if $(EIGHT),$(BLANT_CANON_DIR)/subcanon_map8-7.txt) $(if $(SEVEN),$(BLANT_CANON_DIR)/subcanon_map7-6.txt) $(BLANT_CANON_DIR)/subcanon_map6-5.txt $(BLANT_CANON_DIR)/subcanon_map5-4.txt $(BLANT_CANON_DIR)/subcanon_map4-3.txt
-magic_table_txts := $(foreach k,$(K), orca_jesse_blant_table/UpperToLower$(k).txt)
-
-# ehd takes up too much space and isn't used anywhere yet
-#ehd_txts := $(foreach k,$(K), $(BLANT_CANON_DIR)/EdgeHammingDistance$(k).txt)
-
-base: ./.notpristine show-gcc-ver libwayne $(canon_all) magic_table blant test_all
-
-##################################################################################################################
-####### this is an attempt to create rules to make data files for just ONE value of k... but not working yet...
-# orca_jesse_blant_table and $(BLANT_CANON_DIR)/sub$(BLANT_CANON_DIR) both list the entirety of canon maps as prerequisites
-# thus trying to include them as a prerequisite for just one value of k builds them all
-k3: $(addsuffix 3.txt, $(canon_txt)) $(addsuffix 3.bin, $(canon_bin)) # orca_jesse_blant_table/UpperToLower3.txt
-k4: $(addsuffix 4.txt, $(canon_txt)) $(addsuffix 4.bin, $(canon_bin)) # orca_jesse_blant_table/UpperToLower4.txt $(BLANT_CANON_DIR)/subcanon_map4-3.txt
-k5: $(addsuffix 5.txt, $(canon_txt)) $(addsuffix 5.bin, $(canon_bin)) # orca_jesse_blant_table/UpperToLower5.txt $(BLANT_CANON_DIR)/subcanon_map5-4.txt
-k6: $(addsuffix 6.txt, $(canon_txt)) $(addsuffix 6.bin, $(canon_bin)) # orca_jesse_blant_table/UpperToLower6.txt $(BLANT_CANON_DIR)/subcanon_map6-5.txt
-k7: $(addsuffix 7.txt, $(canon_txt)) $(addsuffix 7.bin, $(canon_bin)) # orca_jesse_blant_table/UpperToLower7.txt $(BLANT_CANON_DIR)/subcanon_map7-6.txt
-k8: $(addsuffix 8.txt, $(canon_txt)) $(addsuffix 8.bin, $(canon_bin)) # orca_jesse_blant_table/UpperToLower8.txt $(BLANT_CANON_DIR)/subcanon_map8-7.txt
-##################################################################################################################
-
-.PHONY: k3 k4 k5 k6 k7 k8
-
-
-show-gcc-ver:
-	$(GCC) -v
-
-./.notpristine:
-	@echo '************ READ THIS. REALLY. WE MEAN IT. READ IT AT LEAST ONCE **************'
-	@echo "If you haven't already, you should read the README at"
-	@echo "	https://github.com/waynebhayes/BLANT#readme"
-	@echo "BLANT can sample graphlets of up to k=8 nodes. The lookup table for k=8 can take"
-	@echo "up to an hour to generate, but is needed if you want BLANT-seed to work, and so"
-	@echo "we make it by default; set NO8=1 to turn it off."
-	@echo "The best way to start the very first time is to run the following command:"
-	@echo "    ./regression-test-all.sh -make"
-	@echo "This may take an hour or more but performs a full battery of tests."
-	@echo "The fastest way to get started is to skip k=8 graphlets:"
-	@echo "    PAUSE=0 NO8=1 make base"
-	@echo "which will make everything needed to get started sampling up to k=7 graphlets".
-	@echo "To skip cleaning and re-making libwayne, set NO_CLEAN_LIBWAYNE=1"
-	@echo "You will only see this message once on a 'pristine' repo. Pausing $(PAUSE) seconds..."
-	@echo '****************************************'
-	sleep $(PAUSE)
-	@touch .notpristine
-
-most: base Draw sub$(BLANT_CANON_DIR)
-
-test_all: $(BLANT_CANON_DIR)/test_index_mode $(BLANT_CANON_DIR)/check_maps test_fast
-
-all: most test_all
-
-$(BLANT_CANON_DIR): base $(canon_all) sub$(BLANT_CANON_DIR)
-
-.PHONY: all test_all most pristine clean_$(BLANT_CANON_DIR)
-
-### Executables ###
-
-fast-canon-map: libwayne $(SRCDIR)/fast-canon-map.c | $(SRCDIR)/blant.h $(OBJDIR)/libblant.o
-	$(CC) '-std=c99' -O3 -o $@ $(OBJDIR)/libblant.o $(SRCDIR)/fast-canon-map.c $(LIBWAYNE_BOTH)
-
-slow-canon-maps: libwayne $(SRCDIR)/slow-canon-maps.c | $(SRCDIR)/blant.h $(OBJDIR)/libblant.o
-	$(CC) -o $@ $(OBJDIR)/libblant.o $(SRCDIR)/slow-canon-maps.c $(LIBWAYNE_BOTH)
-
-make-orbit-maps: libwayne $(SRCDIR)/make-orbit-maps.c | $(SRCDIR)/blant.h $(OBJDIR)/libblant.o
-	$(CC) -o $@ $(OBJDIR)/libblant.o $(SRCDIR)/make-orbit-maps.c $(LIBWAYNE_BOTH)
-
-blant: libwayne $(OBJS) $(OBJDIR)/libblant.o | $(LIBWAYNE_HOME)/C++/mt19937.o # $(OBJDIR)/convert.o $(LIBWAYNE_HOME)/C++/FutureAsync.o
-	$(CXX) -o $@ $(OBJDIR)/libblant.o $(OBJS) $(LIBWAYNE_HOME)/C++/mt19937.o $(LIBWAYNE_LINK) # $(OBJDIR)/convert.o $(LIBWAYNE_HOME)/C++/FutureAsync.o
-	./canon-upper.sh
-
-$(OBJDIR)/%.o: $(SRCDIR)/%.c $(BLANT_HEADERS)
-	@mkdir -p $(dir $@)
-	$(CC) -c -o $@ $< $(LIBWAYNE_COMP)
-
-synthetic: libwayne $(SRCDIR)/synthetic.c $(SRCDIR)/syntheticDS.h $(SRCDIR)/syntheticDS.c | $(OBJDIR)/libblant.o
-	$(CC) -c $(SRCDIR)/syntheticDS.c $(SRCDIR)/synthetic.c $(LIBWAYNE_COMP)
-	$(CXX) -o $@ syntheticDS.o $(OBJDIR)/libblant.o synthetic.o $(LIBWAYNE_LINK)
-
-makeEHD: $(OBJDIR)/makeEHD.o
-	$(CXX) -o $@ $(OBJDIR)/libblant.o $(OBJDIR)/makeEHD.o $(LIBWAYNE_LINK)
-
-compute-alphas-NBE: libwayne $(SRCDIR)/compute-alphas-NBE.c | $(OBJDIR)/libblant.o
-	$(CC) -Wall -O3 -o $@ $(SRCDIR)/compute-alphas-NBE.c $(OBJDIR)/libblant.o $(LIBWAYNE_BOTH)
-
-compute-alphas-EBE: libwayne $(SRCDIR)/compute-alphas-EBE.c | $(OBJDIR)/libblant.o
-	$(CC) -Wall -O3 -o $@ $(SRCDIR)/compute-alphas-EBE.c $(OBJDIR)/libblant.o $(LIBWAYNE_BOTH)
-
-# Currently unused target, was the old method for calculating MCMC
-compute-alphas-MCMC-slow: libwayne $(SRCDIR)/compute-alphas-MCMC-slow.c | $(OBJDIR)/libblant.o
-	$(CC) -Wall -O3 -o $@ $(SRCDIR)/compute-alphas-MCMC-slow.c $(OBJDIR)/libblant.o $(LIBWAYNE_BOTH)
-
-compute-alphas-MCMC: libwayne $(SRCDIR)/compute-alphas-MCMC.c | $(OBJDIR)/libblant.o
-	$(CC) -Wall -O3 -o $@ $(SRCDIR)/compute-alphas-MCMC.c $(OBJDIR)/libblant.o $(LIBWAYNE_BOTH)
-
-Draw: Draw/graphette2dot
-
-Draw/graphette2dot: libwayne Draw/DrawGraphette.cpp Draw/Graphette.cpp Draw/Graphette.h Draw/graphette2dotutils.cpp Draw/graphette2dotutils.h  | $(SRCDIR)/blant.h $(OBJDIR)/libblant.o
-	$(CXX) Draw/DrawGraphette.cpp Draw/graphette2dotutils.cpp Draw/Graphette.cpp $(OBJDIR)/libblant.o -o $@ -std=gnu++11 $(LIBWAYNE_BOTH)
-
-make-subcanon-maps: libwayne $(SRCDIR)/make-subcanon-maps.c | $(OBJDIR)/libblant.o
-	$(CC) -Wall -o $@ $(SRCDIR)/make-subcanon-maps.c $(OBJDIR)/libblant.o $(LIBWAYNE_BOTH)
-
-make-orca-jesse-blant-table: libwayne $(SRCDIR)/blant-fundamentals.h $(SRCDIR)/magictable.cpp | $(OBJDIR)/libblant.o
-	$(CXX) -Wall -o $@ $(SRCDIR)/magictable.cpp $(OBJDIR)/libblant.o -std=gnu++11 $(LIBWAYNE_BOTH)
-
-cluster-similarity-graph: libwayne src/cluster-similarity-graph.c
-	$(CC) $(LIBWAYNE_COMP) $(SPEED) -Wall -o $@ $(SRCDIR)/cluster-similarity-graph.c
-
-$(OBJDIR)/blant-predict.o: $(BLANT_PREDICT_SRC)
-	if [ -f $(SRCDIR)/EdgePredict/Makefile ]; then (CC="$(CC) $(PRED_REG_OPT) $(LIBWAYNE_COMP)"; export CC; OBJDIR="$(OBJDIR)"; export OBJDIR; cd $(SRCDIR)/EdgePredict && $(MAKE)); else $(CC) $(PRED_REG_OPT) -c -o $@ $(SRCDIR)/blant-predict.c $(LIBWAYNE_BOTH); fi
-
-### Object Files/Prereqs ###
-
-$(OBJDIR)/convert.o: $(SRCDIR)/convert.cpp
-	@mkdir -p $(dir $@)
-	$(CXX) -c $(SRCDIR)/convert.cpp -o $@ -std=gnu++11
-
-$(LIBWAYNE_HOME)/C++/mt19937.o: libwayne # $(LIBWAYNE_HOME)/C++/FutureAsync.o
-	cd $(LIBWAYNE_HOME)/C++ && $(MAKE)
-
-$(OBJDIR)/libblant.o: libwayne $(SRCDIR)/libblant.c
-	@mkdir -p $(dir $@)
-	$(CC) -c $(SRCDIR)/libblant.c -o $@ $(LIBWAYNE_COMP)
-
-
-$(OBJDIR)/makeEHD.o: libwayne $(SRCDIR)/makeEHD.c | $(OBJDIR)/libblant.o
-	@mkdir -p $(dir $@)
-	$(CC) -c $(SRCDIR)/makeEHD.c -o $@ $(LIBWAYNE_COMP)
-
-
-$(LIBWAYNE_HOME)/Makefile:
-	echo "Hmm, submodule libwayne doesn't seem to exist; getting it now"
-	git submodule init libwayne
-	git submodule update libwayne
-	(cd libwayne && git checkout master && git pull)
-
-libwayne: libwayne/libwayne.a libwayne/libwayne-g.a libwayne/libwayne-pg.a libwayne/libwayne-pg-g.a libwayne/libwayne-nd.a
-
-libwayne/libwayne.a libwayne/libwayne-g.a libwayne/libwayne-pg.a libwayne/libwayne-pg-g.a:
-	(cd libwayne && make all)
-
-
-### Generated File Recipes
-
-# canon_map, canon_list, and canon-...-signature are all targeted together, because they all depend on output from fast-canon-map
-# for simplicity and readability, they can be created seperately, in which canon_list depends on canon_map, and sig depends on canon_list, but it doesn't really matter
-$(BLANT_CANON_DIR)/canon_map%.txt $(BLANT_CANON_DIR)/canon_list%.txt $(BLANT_CANON_DIR)/canon-ordinal-to-signature%.txt: fast-canon-map
-	mkdir -p $(BLANT_CANON_DIR)
-	[ $* -eq 8 -a '(' -f $(BLANT_CANON_DIR)/canon_map$*.txt -o -f $(BLANT_CANON_DIR)/canon_map$*.txt.gz ')' ] || ./fast-canon-map $* | tee $(BLANT_CANON_DIR)/canon_map$*.txt | gawk -F '	' '{if(!($$1 in seen)){seen[$$1]=$$0}else if(NF>split(seen[$$1],tmp,"\t")){seen[$$1]=$$0}}END{n=asorti(seen,sorted,"@ind_num_asc");print n;for(i=1;i<=n;i++)print seen[sorted[i]]}' | cut -f1,3- | tee $(BLANT_CANON_DIR)/canon_list$*.txt | awk 'NR>1{print NR-2, $$1}' > $(BLANT_CANON_DIR)/canon-ordinal-to-signature$*.txt
-
-# directed counterpart (only k values listed in K_DIR)
-$(DIR_CANON_DIR)/canon_map%.txt $(DIR_CANON_DIR)/canon_list%.txt $(DIR_CANON_DIR)/canon-ordinal-to-signature%.txt: fast-canon-map
-	mkdir -p $(DIR_CANON_DIR)
-	@# run only if this k is in K_DIR
-	@if echo "$(K_DIR)" | grep -qw "$*"; then \
-		./fast-canon-map $* directed | tee $(DIR_CANON_DIR)/canon_map$*.txt | gawk -F '\t' '{if(!($$1 in seen)){seen[$$1]=$$0}else if(NF>split(seen[$$1],tmp,"\t")){seen[$$1]=$$0}}END{n=asorti(seen,sorted,"@ind_num_asc");print n;for(i=1;i<=n;i++)print seen[sorted[i]]}' | cut -f1,3- | tee $(DIR_CANON_DIR)/canon_list$*.txt | awk 'NR>1{print NR-2, $$1}' > $(DIR_CANON_DIR)/canon-ordinal-to-signature$*.txt; \
-	fi
-
-$(BLANT_CANON_DIR)/alpha_list_NBE%.txt: compute-alphas-NBE $(BLANT_CANON_DIR)/canon_list%.txt
-	./compute-alphas-NBE $* > $@
-
-$(BLANT_CANON_DIR)/alpha_list_EBE%.txt: compute-alphas-EBE $(BLANT_CANON_DIR)/canon_list%.txt
-	./compute-alphas-EBE $* > $@
-
-$(BLANT_CANON_DIR)/alpha_list_MCMC%.txt: compute-alphas-MCMC $(BLANT_CANON_DIR)/canon_list%.txt
-	./compute-alphas-MCMC $* > $(BLANT_CANON_DIR)/alpha_list_MCMC$*.txt;
-
-$(BLANT_CANON_DIR)/orbit_map%.txt: make-orbit-maps
-	./make-orbit-maps $* > $(BLANT_CANON_DIR)/orbit_map$*.txt
-
-# directed orbit maps
-$(DIR_CANON_DIR)/orbit_map%.txt: make-orbit-maps
-	./make-orbit-maps $* directed > $(DIR_CANON_DIR)/orbit_map$*.txt
-
-# future goal- make create-bin-data executable it's own seperate target and move it to the prereqs section, and then list create-bin-data as a prereq for .bin files
-$(BLANT_CANON_DIR)/canon_map%.bin $(BLANT_CANON_DIR)/perm_map%.bin: $(SRCDIR)/create-bin-data.c $(BLANT_CANON_DIR)/canon_list%.txt $(BLANT_CANON_DIR)/canon_map%.txt
-	# compile create-bin-data.c to create-bin-data[k] executables
-	$(CC) '-std=c99' "-Dkk=$*" "-DkString=\"$*\"" -o create-bin-data$* $(SRCDIR)/libblant.c $(SRCDIR)/create-bin-data.c $(LIBWAYNE_BOTH)
-	[ -f $(BLANT_CANON_DIR)/canon_map$*.bin -a -f $(BLANT_CANON_DIR)/perm_map$*.bin ] || ./create-bin-data$*
-
-# and copy bin versions for directed k<=6
-$(DIR_CANON_DIR)/canon_map%.bin $(DIR_CANON_DIR)/perm_map%.bin: \
-	$(SRCDIR)/create-bin-data.c \
-	$(DIR_CANON_DIR)/canon_list%.txt \
-	$(DIR_CANON_DIR)/canon_map%.txt \
-	$(DIR_CANON_DIR)/canon_map%.bin $(DIR_CANON_DIR)/perm_map%.bin
-	# reuse same create-bin-data executable, but tell it we are working with directed data
-	[ -f $(DIR_CANON_DIR)/canon_map$*.bin -a -f $(DIR_CANON_DIR)/perm_map$*.bin ] || ./create-bin-data$* directed
-
-# Currently unused target
-$(BLANT_CANON_DIR)/EdgeHammingDistance%.txt: makeEHD | $(BLANT_CANON_DIR)/canon_list%.txt $(BLANT_CANON_DIR)/canon_map%.bin
-	@if [ ! -f $(BLANT_CANON_DIR).correct/EdgeHammingDistance$*.txt.xz ]; then ./makeEHD $* > $@; cmp $(BLANT_CANON_DIR).correct/EdgeHammingDistance$*.txt $@; else echo "EdgeHammingDistance8.txt takes weeks to generate; uncompressing instead"; unxz < $(BLANT_CANON_DIR).correct/EdgeHammingDistance$*.txt.xz > $@ && touch $@; fi
-	#(cd $(BLANT_CANON_DIR).correct && ls EdgeHammingDistance$*.txt*) | awk '{printf "cmp $(BLANT_CANON_DIR).correct/%s $(BLANT_CANON_DIR)/%s\n",$$1,$$1}' | sh
-
-.INTERMEDIATE: .created-subcanon-maps
-sub$(BLANT_CANON_DIR): $(subcanon_txts) ;
-$(subcanon_txts): .created-subcanon-maps
-.created-subcanon-maps: make-subcanon-maps | $(canon_all) #$(canon_list_txts) $(canon_map_bins)
-	# only do it for k > 3 since it's 4-3, 5-4, etc.
-	for k in $(K); do if [ $$k -gt 3 ]; then ./make-subcanon-maps $$k > $(BLANT_CANON_DIR)/subcanon_map$$k-$$(($$k-1)).txt; fi; done
-	# make directed subcanon maps as well for k values where they exist
-	for k in $(K_DIR); do if [ $$k -gt 3 ]; then ./make-subcanon-maps $$k directed > $(DIR_CANON_DIR)/subcanon_map$$k-$$(($$k-1)).txt; fi; done
-
-magic_table: $(magic_table_txts) ;
-$(magic_table_txts): make-orca-jesse-blant-table | $(canon_all) #$(canon_list_txts) $(canon_map_bins)
-	./make-orca-jesse-blant-table $(if $(EIGHT),8,$(if $(SEVEN),7,6))
-
-### Testing ###
-
-blant-sanity: libwayne $(SRCDIR)/blant-sanity.c
-	$(CC) -o $@ $(SRCDIR)/blant-sanity.c $(LIBWAYNE_BOTH)
-
-test_stamp: blant blant-sanity $(canon_all) $(subcanon_txts)
-	@echo Touching test_stamp so $(BLANT_CANON_DIR)/check_maps and $(BLANT_CANON_DIR)/test_index_mode tests only occur if the $(BLANT_CANON_DIR) are changed.
-	@# If $(BLANT_CANON_DIR)/canon_map8.txt is the only outdated prerequisite, it's fine, because the .gz version exists
-	@if [ -n "$?" ] && { [ "$$(echo "$?" | wc -w)" -ne 1 ] || [ "$?" != "$(BLANT_CANON_DIR)/canon_map8.txt" ]; }; then \
-		touch test_stamp; \
-	fi
-
-test_fast: blant blant-sanity
-	# Run blant sanity test only for MCMC tables. If this fails, chances are EVERYTHING ELSE is wrong. These tests will run every time base is made
-	for k in $(K); do if [ -f $(BLANT_CANON_DIR)/canon_map$$k.bin ]; then echo FAST basic sanity for ONLY MCMC with k=$$k; ./blant -q -s MCMC -mi -n 100000 -k $$k networks/syeast.el | sort -n | ./blant-sanity $$k 100000 networks/syeast.el; fi; done
-
-$(BLANT_CANON_DIR)/test_index_mode: test_stamp
-	touch $(BLANT_CANON_DIR)/test_index_mode
-	# First run blant-sanity for various values of k
-	for S in NBE MCMC EBE; do for k in $(K); do if [ -f $(BLANT_CANON_DIR)/canon_map$$k.bin ]; then echo basic sanity check sampling method $$S indexing k=$$k; ./blant -q -s $$S -mi -n 100000 -k $$k networks/syeast.el | sort -n | ./blant-sanity $$k 100000 networks/syeast.el; fi; done; done
-
-$(BLANT_CANON_DIR)/check_maps: test_stamp
-	touch $(BLANT_CANON_DIR)/check_maps
-	ls $(BLANT_CANON_DIR).correct/ | egrep -v 'canon_list2|$(if $(SEVEN),,7|)$(if $(EIGHT),,8|)README|\.[gx]z|EdgeHamming' | awk '{printf "cmp $(BLANT_CANON_DIR).correct/%s $(BLANT_CANON_DIR)/%s\n",$$1,$$1}' | sh
-
-.PHONY: test_fast
-
-### Cleaning ###
+# Waywe needs gcc-6 on MacOS:
+ifndef GCC_VER
+    GCC_VER=$(shell echo $(UNAME) $(HOME) | awk '/Darwin/&&/Users.wayne/{V="-6"}END{if(V)print V;else{printf "using default gcc: " > "/dev/null"; exit 1}}')
+endif
+GCC=gcc$(GCC_VER) # gcc gcc-4.2 gcc-6 gcc-7 gcc-8 gcc-9 # Possibilities on Darwin
+CXX=g++$(GXX_VER)
+STACKSIZE=$(shell ($(GCC) -v 2>&1; uname -a) | awk '/CYGWIN/{print "-Wl,--stack,83886080"}/gcc-/{actualGCC=1}/Darwin/&&actualGCC{print "-Wl,-stack_size -Wl,0x5000000"}')
+CC=$(GCC) $(OPT) $(GDB) $(DEBUG) -Wno-unused-variable -Wno-unused-but-set-variable -Wall -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wshadow $(PG) $(STACKSIZE)
+LIBWAYNE_HOME:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Safe to call whenever a previous full make call has succeeded, call this after a source file has changed.
+incremental:
+	cd src; $(MAKE) -f Makefile.incremental 'CC=$(GCC)'
+
+make-successful:
+	touch make-started # create this file so it is OLDER than .a files
+	make all
+	mv make-started make-successful
+
+all:
+	@if [ -f do-not-make ]; then echo "not making; assuming they already exist"; ls -l libwayne*.a; else /bin/rm -f *.a; $(MAKE) libwayne_all; fi
+	$(MAKE) testlib
+
+
+# Run 'make watch' in a separate terminal for auto-recompilation 
+watch:
+	ls src/*.c include/*.h | entr $(MAKE) incremental
+
+libwayne_all: parallel
+	/bin/rm -f *.a src/*.a
+	$(CC) -o bin/intSizes intSizes.c && ./bin/intSizes > include/intSizes.h
+
+	$(MAKE) libwayne_one VARIANT=libwayne       PG_FLAG=    DBG=  NDEBUG_FLAG=          OPT_FLAGS=-O2
+	$(MAKE) libwayne_one VARIANT=libwayne-nd    PG_FLAG=    DBG=  NDEBUG_FLAG=-DNDEBUG  OPT_FLAGS=-O2
+	$(MAKE) libwayne_one VARIANT=libwayne-g     PG_FLAG=    DBG=1 NDEBUG_FLAG=          OPT_FLAGS=
+	$(MAKE) libwayne_one VARIANT=libwayne-pg    PG_FLAG=-pg DBG=  NDEBUG_FLAG=          OPT_FLAGS=-O2
+	$(MAKE) libwayne_one VARIANT=libwayne-pg-nd PG_FLAG=-pg DBG=  NDEBUG_FLAG=-DNDEBUG  OPT_FLAGS=-O2
+	$(MAKE) libwayne_one VARIANT=libwayne-pg-g  PG_FLAG=-pg DBG=1 NDEBUG_FLAG=          OPT_FLAGS=
+
+empty :=
+space := $(empty) $(empty)
+
+VARIANT := $(subst $(space),-,$(strip \
+	$(if $(PG_FLAG),pg) \
+	$(if $(DBG),g) \
+	$(if $(NDEBUG_FLAG),nd) \
+	$(if $(OPT_FLAGS),$(subst -,,$(OPT_FLAGS))) \
+))
+
+VARIANT := libwayne$(if $(VARIANT),-$(VARIANT),)
+
+libwayne_one:
+	mkdir -p build/$(VARIANT)
+	echo "$(strip $(OPT_FLAGS) $(PG_FLAG) $(if $(DBG),-ggdb -DDEBUG=1,$(NDEBUG_FLAG)))" > build/$(VARIANT)/.cflags
+	$(MAKE) -j$(CORES) \
+		'PG=$(PG_FLAG)' \
+		'OPT=$(OPT_FLAGS)' \
+		'GDB=$(if $(DBG),-ggdb)' \
+		'DEBUG=$(if $(DBG),-DDEBUG=1,$(NDEBUG_FLAG))' \
+		'OBJDIR=../build/$(VARIANT)' \
+		'LIBOUT=$(VARIANT).a' \
+		libwayne
+	/bin/rm -f src/$(VARIANT).a
+	mkdir -p build/.stamps && for o in build/$(VARIANT)/*.o; do touch build/.stamps/$$(basename $${o%.o}).stamp; done
+
+parallel: parallel.c
+	$(CC) -o bin/parallel parallel.c
+
+testlib:
+	export LIBWAYNE_HOME=$(LIBWAYNE_HOME); for x in ebm covar stats hash raw_hashmap htree-test avltree-test bintree-test CI graph-sanity tinygraph-sanity graph-weighted circ_buf; do rm -f bin/$$x tests/$$x.o; ( cd tests; $(MAKE) $$x; mv $$x ../bin; IN=/dev/null; [ -f $$x.in ] && IN=$$x.in; cat $$IN | ../bin/$$x $$x.in > /tmp/$$x.test$$$$ 2>&1 || exit 1; cat /tmp/$$x.test$$$$ | if [ -f $$x.out ]; then cmp - $$x.out; else wc; fi; /bin/rm -f /tmp/$$x.test$$$$); done #sim_anneal
+
+opt:
+	$(MAKE) 'OPT=-O2' 'DEBUG=-DNDEBUG' 'LIBOUT=libwayne.a' libwayne
+
+debug:
+	$(MAKE) 'GDB=-ggdb' 'DEBUG=-DDEBUG=1' 'LIBOUT=libwayne-g.a' libwayne
+
+shared-opt:
+	$(MAKE) 'OPT=-O2 -fPIC' 'LIBOUT=libwayne.a' libwayne
+
+shared-debug:
+	$(MAKE) 'OPT=-fPIC' 'GDB=-ggdb' 'DEBUG=-DDEBUG=1' 'LIBOUT=libwayne-g.a' libwayne
+
+ndebug:
+	$(MAKE) 'OPT=-O2' 'DEBUG=-DNDEBUG=1' 'LIBOUT=libwayne-nd.a' libwayne
+
+libwayne:
+	$(MAKE) $(LIBOUT)
+	# add misc.o below since adding nothing fails on Mac M1, and misc.o is pretty much necessary for libwayne to work.
+	[ "$(UNAME)" = Darwin ] || ar r $(LIBOUT) build/$(notdir $(OBJDIR))/misc.o
+
+debug_clean:
+	@$(MAKE) 'GDB=-ggdb' 'DEBUG=-DDEBUG=1' 'LIBOUT=libwayne-g.a' raw_clean
+
+opt_clean:
+	@$(MAKE) 'OPT=-O2' 'LIBOUT=libwayne.a' raw_clean
+
+ndebug_clean:
+	@$(MAKE) 'OPT=-O2' 'LIBOUT=libwayne-nd.a' raw_clean
+
+raw_clean:
+	rm -f make-successful
+	@/bin/rm -f src/*.[oa] $(LIBOUT)
+	@cd C++; $(MAKE) clean
 
 clean:
-	@/bin/rm -f *.[oa] blant create-bin-data3 create-bin-data4 create-bin-data5 create-bin-data6 create-bin-data7 create-bin-data8 canon-sift fast-canon-map make-orbit-maps compute-alphas-MCMC-slow compute-alphas-MCMC compute-alphas-NBE compute-alphas-EBE make-orca-jesse-blant-table Draw/graphette2dot blant-sanity make-subcanon-maps test_stamp $(BLANT_CANON_DIR)/check_maps $(BLANT_CANON_DIR)/test_index_mode
-	@/bin/rm -rf $(OBJDIR)/*
-	@/bin/rm -rf $(DIR_CANON_DIR)/* || true
+	rm -f make-successful
+	rm -rf build
+	@/bin/rm -rf src/libwayne*/
+	@# The following is meant to remove the non-Windows binary, ie stats but not stats.exe.
+	@/bin/rm -f bin/stats bin/raw_hashmap bin/hash
+	@/bin/rm -f *.a src/*.a
+	@$(MAKE) debug_clean
+	@$(MAKE) opt_clean
 
-realclean:
-	echo "'realclean' is now called 'pristine'; try again"
-	false
+$(LIBOUT): src/$(LIBOUT)
+	if ranlib src/$(LIBOUT); then :; else echo "ranlib failed but it's not crucial" >&2; fi
+	cp -p src/$(LIBOUT) .
 
-pristine: clean clean_$(BLANT_CANON_DIR)
-ifndef NO_CLEAN_LIBWAYNE
-	@cd $(LIBWAYNE_HOME); $(MAKE) clean
-endif
-	@find $(BLANT_CANON_DIR) -maxdepth 1 -not -type d -delete; /bin/rm -f .notpristine .firsttime # .firsttime is the old name but remove it anyway
-	@echo "Finding all python crap and removing it... this may take awhile..." >/dev/null
-	@./scripts/delete-python-shit.sh $(UNAME)
+.PHONY: src/$(LIBOUT)
+src/$(LIBOUT):
+	cd src; $(MAKE) -f Makefile.all 'CC=$(CC)' 'LIBOUT=$(LIBOUT)' 'GDB=$(GDB)' 'OBJDIR=$(OBJDIR)' '$(LIBOUT)'
 
-clean_$(BLANT_CANON_DIR):
-	@/bin/rm -f $(BLANT_CANON_DIR)/*[3-7].* # don't remove 8 since it takes too long to create
-	@/bin/rm -f $(DIR_CANON_DIR)/*[3-6].* || true # directed only goes through k=6
-	@/bin/rm -f orca_jesse_blant_table/UpperToLower*.txt
+#.PHONY: libwayne-pg-g src/$(LIBOUT)

--- a/src/Makefile.incremental
+++ b/src/Makefile.incremental
@@ -1,0 +1,31 @@
+# Incremental build: recompile changed .c files for all built variants only.
+# Run from libwayne/ via: make incremental
+# Discovers which variants exist by looking for ../libwayne*.a files.
+# Uses per-variant ../build/VARIANT/.cflags to know what flags to compile with.
+# Stamps live in build/.stamps/ — no .o files are written to src/.
+
+SRCS=llfile.c stream48.c longlong.c bitvec.c sets.c smallgraph-transitive.c misc.c dverk.c rkd78.c lsode.c ddriv2.c bsode.c ldbsode.c rk4.c rk4s.c rk12.c rk23.c stack.c event.c heap.c linked-list.c stats.c queue.c compressedInt.c Oalloc.c variable_leapfrog.c leapfrog.c htree.c avltree.c bintree.c eigen.c mem-debug.c smallgraph.c tinygraph.c graph.c combin.c matvec.c sorts.c heun_euler.c multisets.c dynarray.c #raw_hashmap.c #qrkd78.c iqrkd78.c
+
+STAMP_DIR := ../build/.stamps
+STAMPS := $(patsubst %.c,$(STAMP_DIR)/%.stamp,$(filter %.c,$(SRCS)))
+
+INCLUDE=-I../include
+CFLAGS=$(INCLUDE)
+
+BUILT_VARIANTS := $(patsubst ../%.a,%,$(wildcard ../libwayne*.a))
+
+all: mk-dirs $(STAMPS)
+
+mk-dirs:
+	@mkdir -p $(STAMP_DIR)
+	@for V in $(BUILT_VARIANTS); do mkdir -p ../build/$$V; done
+
+$(STAMP_DIR)/%.stamp: %.c
+	@for V in $(BUILT_VARIANTS); do \
+	    F=$$(cat ../build/$$V/.cflags 2>/dev/null || echo "-O2"); \
+	    $(CC) $(CFLAGS) $$F -c -o ../build/$$V/$*.o $< && ar rcvu ../$$V.a ../build/$$V/$*.o & \
+	done; \
+	wait
+	touch $@
+
+.PHONY: all mk-dirs


### PR DESCRIPTION
Rewrote Makefile with libwayne_one target that allows for custom variant builds via passing compiler flags.
Implemented incremental dynamic recompilation that tracks the timestamps of object files to recompile when source files change via the %.stamp: %.c rule.